### PR TITLE
Set up build test

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install
         run: |
-          pip install --upgrade pip
+          python -m pip install --upgrade pip
+          pip install --upgrade wheel
           pip install -e .
       - name: Test Import
         run: |
@@ -62,7 +63,7 @@ jobs:
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install wheel
+          pip install --upgrade wheel
           pip install -r dev-requirements.txt
       - name: Check Formatting and Lint
         run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,4 @@
-name: Linting and Tests
+name: Build and Test
 
 # trigger on any PR or push to main
 on:
@@ -8,7 +8,32 @@ on:
   pull_request:
 
 jobs:
+  build:
+    name: Build
+    strategy:
+      max-parallel: 4
+      matrix:
+        platform: [ubuntu-latest]
+        python-version: [3.7, 3.8]
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install
+        run: |
+          pip install --upgrade pip
+          pip install -e .
+      - name: Test Import
+        run: |
+          python -c 'import neuralcompression'
+
   lint-and-test:
+    name: Lint and Test
     strategy:
       max-parallel: 4
       matrix:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NeuralCompression
 
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/facebookresearch/NeuralCompression/tree/main/LICENSE)
-[![Linting and Tests](https://github.com/facebookresearch/NeuralCompression/actions/workflows/linting-and-tests.yml/badge.svg)](https://github.com/facebookresearch/NeuralCompression/actions/workflows/linting-and-tests.yml)
+[![Build and Test](https://github.com/facebookresearch/NeuralCompression/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/facebookresearch/NeuralCompression/actions/workflows/build-and-test.yml)
 
 ## What's New
 


### PR DESCRIPTION
Adds a build test for installing the package and importing. The reason for adding this test is that when adding a new feature a developer might add new requirements to `dev-requirements.txt` but forget to update `install_requires`. At a minimum the package should be importable with what's in `install_requires`.