### PR TITLE
Adding Flop Counter

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
 
 # modules that don't play well with mypy
-[mypy-torchvision.*,PIL.*,compressai.*,tqdm.*,lpips.*]
+[mypy-torchvision.*,PIL.*,compressai.*,tqdm.*,lpips.*,fvcore.*]
 ignore_missing_imports=True

--- a/neuralcompression/functional/__init__.py
+++ b/neuralcompression/functional/__init__.py
@@ -5,6 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
 
+from .complexity import count_flops
 from .distortion import (
     learned_perceptual_image_patch_similarity,
     multiscale_structural_similarity,

--- a/neuralcompression/functional/complexity.py
+++ b/neuralcompression/functional/complexity.py
@@ -9,7 +9,7 @@ from copy import copy
 from typing import Any, Dict, Optional, Sequence, Tuple
 
 from fvcore.nn import FlopCountAnalysis
-from fvcore.nn.jit_handles import generic_activation_jit, Handle
+from fvcore.nn.jit_handles import Handle, generic_activation_jit
 from torch import nn
 
 # These ops aren't supported by fvcore - we estimate their FLOPs

--- a/neuralcompression/functional/complexity.py
+++ b/neuralcompression/functional/complexity.py
@@ -1,0 +1,118 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from typing import Any, Callable, Dict, Optional, Tuple
+from torch import nn
+from copy import copy
+
+from fvcore.nn.jit_handles import generic_activation_jit
+from fvcore.nn import FlopCountAnalysis
+
+# These ops aren't supported by fvcore - we estimate their FLOPs
+# by counting 1 FLOP per element of the output tensor. Note that
+# this method handles broadcasting shapes.
+_OPS_TO_ADD = [
+    f"aten::{name}"
+    for name in [
+        "abs",
+        "add",
+        "div",
+        "erfc",
+        "exp",
+        "log",
+        "log10",
+        "log2",
+        "mul",
+        "neg",
+        "pow",
+        "reciprocal",
+        "rsqrt",
+        "rsub",
+        "sigmoid",
+        "sign",
+        "softplus",
+        "sqrt",
+        "sub",
+        "tanh",
+        "uniform",
+    ]
+]
+
+# Creating counter functions for all the ops listed above, in addition
+# to their inplace (trailing underscore) equivalents.
+_ADDITONAL_COUNTERS = {
+    name: generic_activation_jit(name)
+    for name in _OPS_TO_ADD + [f"{n}_" for n in _OPS_TO_ADD]
+}
+
+# Expanding on the 0-FLOP op list from fvcore here:
+# https://github.com/facebookresearch/fvcore/blob/166a030e093013a934642ca3744592a2e3de5ea2/fvcore/nn/jit_analysis.py#L27
+_OPS_TO_IGNORE = ["aten::empty_like"]
+
+
+def count_flops(
+    module: nn.Module,
+    inputs: Tuple[Any, ...],
+    counter_overrides: Optional[Dict[str, Callable]] = None,
+) -> Tuple[float, Dict[str, float], Dict[str, int]]:
+    """
+    Counts the FLOPs in the forward function of an ``nn.Module``.
+
+    Given a model, this counter first uses TorchScript to trace the
+    model's forward function into a series of linear algebra operations
+    (e.g. matmuls, convolutions, etc.). Then the FLOPs of each operation
+    are counted, provided that the operator type has a corresponding flop
+    counting function registered. Note that a multiply-accumulate is
+    considered one FLOP, not two.
+
+    If an operator does not have a registered counter, it is ignored in the
+    flop count and is logged as an unregistered op in the function's return
+    value (see below). Most common operations already have
+    registered counters, but it may be necessary to register additional
+    operators in the counter_overrides field.
+
+    This function relies on the fvcore flop counter, accessible here:
+    https://github.com/facebookresearch/fvcore
+
+    Args:
+        module: the ``nn.Module`` whose forward function will be profiled.
+        inputs: a tuple of Tensors to pass as inputs to ``module``
+            when it is traced.
+        counter_overrides: a dictionary mapping operator names to
+            FLOP-counting functions, to extend/override the default
+            registered operators. A counting function's signature
+            should take in a list of operator inputs and a list
+            of operator outputs (in that order), and return the
+            operator's FLOP count. See the fvcore documentation
+            for more details.
+
+    Returns:
+        A tuple of:
+            - The total number of FLOPs recorded in the model's
+            forward function (returned as a float).
+            - A dictionary breaking down the total model FLOPs by
+            operator (i.e. a dictionary mapping from operator names
+            to the total FLOPs performed by all calls to that operator
+            in the model).
+            - A dictionary recording all the unsupported model operations,
+            i.e. operations who don't have associated FLOP-counting
+            functions. This dictionary maps the names of unsupported operators
+            to the number of times that operator was invoked by the model.
+    """
+
+    counters_to_add = copy(_ADDITONAL_COUNTERS)
+    if counter_overrides is not None:
+        counters_to_add.update(counter_overrides)
+
+    counter = FlopCountAnalysis(module, inputs).set_op_handle(**counters_to_add)
+    for name in _OPS_TO_IGNORE:
+        counter._ignored_ops.add(name)
+    return (
+        counter.total(),
+        dict(counter.by_operator().items()),
+        counter.unsupported_ops(),
+    )

--- a/neuralcompression/functional/complexity.py
+++ b/neuralcompression/functional/complexity.py
@@ -12,44 +12,72 @@ from fvcore.nn import FlopCountAnalysis
 from fvcore.nn.jit_handles import Handle, generic_activation_jit
 from torch import nn
 
-# These ops aren't supported by fvcore - we estimate their FLOPs
-# by counting 1 FLOP per element of the output tensor. Note that
-# this method handles broadcasting input shapes.
-_OPS_TO_ADD = [
+# These ops aren't supported (i.e. are ignored) by fvcore - we calculate
+# their flops by counting 1 flop per element of the output tensor. Note that
+# this approach handles broadcasting input shapes.
+_SINGLE_FLOP_OPS_TO_ADD = [
     f"aten::{name}"
     for name in [
         "abs",
         "add",
         "div",
+        "mul",
+        "neg",
+        "rsub",
+        "sign",
+        "sub",
+    ]
+]
+
+
+# These ops are also unsupported by fvcore, but unlike those in the
+# above list, these ops likely require more than 1 flop per
+# output element, and their counts can vary depending on
+# platform implementation. For correctness' sake, by default we keep
+# these ops as unregistered/ignored. However, if your model has lots of these
+# operations and you wish to obtain a rough estimate of their contributions
+# to total model complexity, for convenience we expose the
+# use_single_flop_estimates flag. If True, this flag will 
+# register counter functions for the ops below
+# that count 1 flop per output element. If you know exactly 
+# how many flops some of these ops should have on your platform, 
+# use the counter_overrides argument.
+_SINGLE_FLOP_ESTIMATES_TO_ADD = [
+    f"aten::{name}"
+    for name in [
         "erfc",
         "exp",
         "log",
         "log10",
         "log2",
-        "mul",
-        "neg",
         "pow",
         "reciprocal",
         "rsqrt",
-        "rsub",
         "sigmoid",
-        "sign",
         "softplus",
         "sqrt",
-        "sub",
         "tanh",
         "uniform",
     ]
 ]
 
-# Creating counter functions for all the ops listed above, in addition
-# to their inplace (trailing underscore) equivalents.
-_ADDITONAL_COUNTERS = {
+# Creating counter functions for all the ops listed in
+# _SINGLE_FLOP_OPS_TO_ADD, in addition to their inplace
+# (trailing underscore) equivalents.
+_SINGLE_FLOP_OP_COUNTERS = {
     name: generic_activation_jit(name)
-    for name in _OPS_TO_ADD + [f"{n}_" for n in _OPS_TO_ADD]
+    for name in _SINGLE_FLOP_OPS_TO_ADD + [f"{n}_" for n in _SINGLE_FLOP_OPS_TO_ADD]
 }
 
-# Expanding on the 0-FLOP op list from fvcore here:
+# Same as the above, but for the ops to estimate.
+_SINGLE_FLOP_ESTIMATE_COUNTERS = {
+    name: generic_activation_jit(name)
+    for name in _SINGLE_FLOP_ESTIMATES_TO_ADD
+    + [f"{n}_" for n in _SINGLE_FLOP_ESTIMATES_TO_ADD]
+}
+
+
+# Expanding on the 0-flop op list from fvcore here:
 # https://github.com/facebookresearch/fvcore/blob/166a030e093013a934642ca3744592a2e3de5ea2/fvcore/nn/jit_analysis.py#L27
 _OPS_TO_IGNORE = ["aten::empty_like"]
 
@@ -58,16 +86,17 @@ def count_flops(
     module: nn.Module,
     inputs: Sequence[Any],
     counter_overrides: Optional[Dict[str, Handle]] = None,
+    use_single_flop_estimates: bool = False,
 ) -> Tuple[float, Dict[str, float], Dict[str, int]]:
     """
-    Counts the FLOPs in the forward function of an ``nn.Module``.
+    Counts the flops in the forward function of an ``nn.Module``.
 
     Given a model, this counter first uses TorchScript to trace the
     model's forward function into a series of linear algebra operations
-    (e.g. matmuls, convolutions, etc.). Then the FLOPs of each operation
+    (e.g. matmuls, convolutions, etc.). Then the flops of each operation
     are counted, provided that the operator type has a corresponding flop
     counting function registered. Note that a multiply-accumulate is
-    considered one FLOP, not two.
+    considered one flop, not two.
 
     If an operator does not have a registered counter, it is ignored in the
     flop count and is logged as an unregistered op in the function's return
@@ -79,27 +108,44 @@ def count_flops(
     https://github.com/facebookresearch/fvcore
 
     Args:
-        module: the ``nn.Module`` whose forward function will be profiled.
-        inputs: a tuple of Tensors to pass as inputs to ``module``
+        module: The ``nn.Module`` whose forward function will be profiled.
+        inputs: A sequence of variables to pass as inputs to ``module``
             when it is traced.
-        counter_overrides: a dictionary mapping operator names to
-            FLOP-counting functions, to extend/override the default
+        counter_overrides: A dictionary mapping operator names to
+            flop-counting functions, to extend/override the default
             registered operators. A counting function's signature
             should take in a list of operator inputs and a list
             of operator outputs (in that order), and return the
-            operator's FLOP count. See the fvcore documentation
+            operator's flop count. See the fvcore documentation
             for more details.
+        use_single_flop_estimates: Dictates whether to use approximate
+            flop-counting functions for many elementwise ops not
+            supported by fvcore. Many ops, like sqrt, log, pow, etc.,
+            are by default ignored by fvcore, since their true flop count
+            can vary by platform op implementation. For correctness'
+            sake, we too ignore these ops by default. However, if your
+            model has lots of these types of operations and you wish to
+            obtain a rough estimate of their contributions to
+            total model complexity, passing this flag as ``True`` will
+            register conservative counter estimates
+            for these ops that count 1 flop per output tensor element
+            (e.g. 1 sqrt = 1 flop). The full list of ops that this flag
+            registers counters for can be found in
+            ``_SINGLE_FLOP_ESTIMATES_TO_ADD``. If you know exactly how many
+            flops some of these ops should have on your platform, use the
+            ``counter_overrides`` argument.
+
 
     Returns:
-        A tuple of:
-            - The total number of FLOPs recorded in the model's
+        A 3-tuple of:
+            - The total number of flops recorded in the model's
             forward function (returned as a float).
-            - A dictionary breaking down the total model FLOPs by
+            - A dictionary breaking down the total model flops by
             operator (i.e. a dictionary mapping from operator names
-            to the total FLOPs performed by all calls to that operator
+            to the total flops performed by all calls to that operator
             in the model).
             - A dictionary recording all the unsupported model operations,
-            i.e. operations who don't have associated FLOP-counting
+            i.e. operations who don't have associated flop-counting
             functions. This dictionary maps the names of unsupported operators
             to the number of times that operator was invoked by the model.
     """
@@ -108,7 +154,9 @@ def count_flops(
     # will often crash if a list is passed
     inputs = tuple(inputs)
 
-    counters_to_add = copy(_ADDITONAL_COUNTERS)
+    counters_to_add = copy(_SINGLE_FLOP_OP_COUNTERS)
+    if use_single_flop_estimates:
+        counters_to_add.update(_SINGLE_FLOP_ESTIMATE_COUNTERS)
     if counter_overrides is not None:
         counters_to_add.update(counter_overrides)
 

--- a/neuralcompression/functional/complexity.py
+++ b/neuralcompression/functional/complexity.py
@@ -37,10 +37,10 @@ _SINGLE_FLOP_OPS_TO_ADD = [
 # these ops as unregistered/ignored. However, if your model has lots of these
 # operations and you wish to obtain a rough estimate of their contributions
 # to total model complexity, for convenience we expose the
-# use_single_flop_estimates flag. If True, this flag will 
+# use_single_flop_estimates flag. If True, this flag will
 # register counter functions for the ops below
-# that count 1 flop per output element. If you know exactly 
-# how many flops some of these ops should have on your platform, 
+# that count 1 flop per output element. If you know exactly
+# how many flops some of these ops should have on your platform,
 # use the counter_overrides argument.
 _SINGLE_FLOP_ESTIMATES_TO_ADD = [
     f"aten::{name}"

--- a/neuralcompression/functional/complexity.py
+++ b/neuralcompression/functional/complexity.py
@@ -104,7 +104,7 @@ def count_flops(
             to the number of times that operator was invoked by the model.
     """
 
-    # fvcore requires a tuple of inputs and 
+    # fvcore requires a tuple of inputs and
     # will often crash if a list is passed
     inputs = tuple(inputs)
 

--- a/neuralcompression/functional/complexity.py
+++ b/neuralcompression/functional/complexity.py
@@ -5,12 +5,12 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 """
 
-from typing import Any, Callable, Dict, Optional, Tuple
-from torch import nn
 from copy import copy
+from typing import Any, Callable, Dict, Optional, Tuple
 
-from fvcore.nn.jit_handles import generic_activation_jit
 from fvcore.nn import FlopCountAnalysis
+from fvcore.nn.jit_handles import generic_activation_jit
+from torch import nn
 
 # These ops aren't supported by fvcore - we estimate their FLOPs
 # by counting 1 FLOP per element of the output tensor. Note that

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ compressai==1.1.5
 tqdm==4.61.2
 torchmetrics==0.4.1
 lpips==0.1.3
+fvcore==0.1.5.post20210624

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ install_requires = [
     "torchvision>=0.9.1",
     "tqdm>=4.61.0",
     "torchmetrics>=0.3.2",
+    "fvcore>=0.1.5"
 ]
 
 setup(

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -1,0 +1,149 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+import pytest
+import torch
+from torch import nn
+
+import neuralcompression.functional as ncF
+from neuralcompression.models import ScaleHyperprior
+
+
+@pytest.mark.parametrize(
+    "batch_size, dim_in, dim_out",
+    [(1, 1, 1), (2, 1, 10), (3, 10, 10), (4, 10, 1), (5, 6, 7)],
+)
+def test_flop_count_ffn(batch_size, dim_in, dim_out):
+    # Testing the flop counter counts simple modules as expected.
+
+    ffn_model = nn.Sequential(
+        nn.Linear(dim_in, dim_out, bias=False), nn.Linear(dim_out, dim_out, bias=False)
+    )
+    ffn_inputs = (torch.randn(batch_size, dim_in),)
+
+    total_flops, _, unsupported_ops = ncF.count_flops(ffn_model, ffn_inputs)
+    assert total_flops == batch_size * dim_in * dim_out + batch_size * dim_out * dim_out
+    assert len(unsupported_ops) == 0
+
+
+@pytest.mark.parametrize(
+    "input_shape, layer_channels, layer_strides, layer_kernels, layer_padding",
+    (
+        ((1, 3, 64, 64), (10, 6, 11), (1, 2, 1), (1, 2, 3), (0, 1, 5)),
+        ((3, 10, 11, 127), (2, 4, 8, 1), (2, 2, 2, 2), (4, 7, 1), (0, 2, 3, 0)),
+    ),
+)
+def test_flop_count_conv(
+    input_shape, layer_channels, layer_strides, layer_kernels, layer_padding
+):
+    # Testing that the flop counter counts a convolutional model as expected
+    # (i.e. when compared to a reference value).
+
+    class ConvModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layers = nn.ModuleList()
+            cin = input_shape[1]
+
+            for cout, stride, kernel, padding in zip(
+                layer_channels, layer_strides, layer_kernels, layer_padding
+            ):
+                self.layers.append(
+                    nn.Conv2d(
+                        cin, cout, kernel_size=kernel, stride=stride, padding=padding
+                    )
+                )
+                cin = cout
+
+        def forward(self, inp):
+            flops = torch.tensor(0)
+            out = inp
+            for layer, k_size in zip(self.layers, layer_kernels):
+                cin = out.shape[1]
+                out = layer(out)
+                # +3 for counting the additions to the flops variable itself
+                flops += out.numel() * k_size * k_size * cin + 3
+
+            return out, flops
+
+    model = ConvModel()
+    inp = torch.randn(input_shape)
+    _, correct_flops = model(inp)
+
+    counted_flops, _, unsupported_ops = ncF.count_flops(model, (inp,))
+    assert torch.allclose(torch.tensor(counted_flops).long(), correct_flops)
+    assert len(unsupported_ops) == 0
+
+
+@pytest.mark.parametrize("input_shape", ((10, 3), (1, 1), (5, 9), (10, 9, 8)))
+def test_flop_count_elementwise(input_shape):
+    # Tests that the flop counter counts flops correctly (i.e.
+    # when compared to a reference value) for a model involving
+    # lots of binary and elementwise operations.
+
+    class ElementwiseModel(nn.Module):
+        def forward(self, inp):
+            flops = torch.tensor(0)
+            out = inp
+
+            out = out * 2
+            # +1 here and below for counting the additions to the flop
+            # variable itself.
+            flops += out.numel() + 1
+
+            out = out.pow(2).exp().log()
+            flops += out.numel() * 3 + 1
+
+            out = out.view(-1, 1) @ out.view(1, -1)
+            flops += out.numel() + 1
+
+            out = out + out
+            flops += out.numel() + 1
+
+            return out, flops
+
+    model = ElementwiseModel()
+    inp = torch.randn(input_shape)
+    _, correct_flops = model(inp)
+
+    counted_flops, _, unsupported_ops = ncF.count_flops(model, (inp,))
+    assert torch.allclose(torch.tensor(counted_flops).long(), correct_flops)
+    assert len(unsupported_ops) == 0
+
+
+@pytest.mark.parametrize(
+    "batch_size, network_channels, compression_channels, img_size", [(1, 8, 16, 128)]
+)
+def test_flop_count_hyperprior(
+    batch_size, network_channels, compression_channels, img_size
+):
+    # Testing that the flop counter doesn't crash and records all operators
+    # on a more complicated model, i.e. the scale hyperprior model.
+    model = ScaleHyperprior(
+        network_channels=network_channels, compression_channels=compression_channels
+    )
+    inputs = (torch.randn(batch_size, 3, img_size, img_size),)
+    _, _, unsupported_ops = ncF.count_flops(model, inputs)
+    assert len(unsupported_ops) == 0
+
+
+def test_flop_counter_overrides():
+    class Addition(nn.Module):
+        def forward(self, x, y):
+            return x + y
+
+    add_count_override = 1234567.0
+
+    count, _, _ = ncF.count_flops(
+        Addition(),
+        (torch.tensor(5.0), torch.tensor(6.0)),
+        counter_overrides={"aten::add": lambda x, y: add_count_override},
+    )
+
+    assert torch.allclose(
+        torch.tensor(count).float(), torch.tensor(add_count_override).float()
+    )

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -132,18 +132,21 @@ def test_flop_count_hyperprior(
 
 
 def test_flop_counter_overrides():
+    # Testing that one can override the counter's default implementation for
+    # an operation with a custom counter function.
+
     class Addition(nn.Module):
         def forward(self, x, y):
             return x + y
 
-    add_count_override = 1234567.0
+    add_override_value = 1234567.0
 
     count, _, _ = ncF.count_flops(
         Addition(),
         (torch.tensor(5.0), torch.tensor(6.0)),
-        counter_overrides={"aten::add": lambda x, y: add_count_override},
+        counter_overrides={"aten::add": lambda inputs,outputs: add_override_value},
     )
 
     assert torch.allclose(
-        torch.tensor(count).float(), torch.tensor(add_count_override).float()
+        torch.tensor(count).float(), torch.tensor(add_override_value).float()
     )

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -144,7 +144,7 @@ def test_flop_counter_overrides():
     count, _, _ = ncF.count_flops(
         Addition(),
         (torch.tensor(5.0), torch.tensor(6.0)),
-        counter_overrides={"aten::add": lambda inputs,outputs: add_override_value},
+        counter_overrides={"aten::add": lambda inputs, outputs: add_override_value},
     )
 
     assert torch.allclose(

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -110,7 +110,9 @@ def test_flop_count_elementwise(input_shape):
     inp = torch.randn(input_shape)
     _, correct_flops = model(inp)
 
-    counted_flops, _, unsupported_ops = ncF.count_flops(model, (inp,))
+    counted_flops, _, unsupported_ops = ncF.count_flops(
+        model, (inp,), use_single_flop_estimates=True
+    )
     assert torch.allclose(torch.tensor(counted_flops).long(), correct_flops)
     assert len(unsupported_ops) == 0
 
@@ -127,7 +129,9 @@ def test_flop_count_hyperprior(
         network_channels=network_channels, compression_channels=compression_channels
     )
     inputs = (torch.randn(batch_size, 3, img_size, img_size),)
-    _, _, unsupported_ops = ncF.count_flops(model, inputs)
+    _, _, unsupported_ops = ncF.count_flops(
+        model, inputs, use_single_flop_estimates=True
+    )
     assert len(unsupported_ops) == 0
 
 


### PR DESCRIPTION
This PR creates a flop counter to estimate the computational complexity of a model. It wraps the flop-counting utilities from [fvcore](https://github.com/facebookresearch/fvcore/blob/166a030e093013a934642ca3744592a2e3de5ea2/fvcore/nn/flop_count.py) and adds some support for extra operators. 

I gave all of these added operations (e.g. addition, subtraction, sqrt, etc.) a count of 1 flop per output element - this is probably a very rough estimate for some operations, but better than the 0 flops assigned currently by fvcore. If you have better suggestions/estimations for some of the operators in this PR, please let me know.

This PR also adds several unit tests for the flop counter - specifically I made:
- A test that sanity-checks that a small FFN has the flops one would expect. 
- A similar test as the above, but for convolutions.
- A test to make sure that the scale hyperprior model (i.e. a non-trivial model) is able to go through the flop counter without any unsupported operations.
- A test that checks that a model with various elementwise operations, including some with broadcasting shapes, is counted properly.
- A test to make sure the counter's default implementations can be overridden.