### PR TITLE
Ensuring Consistent Dataset Transform Defaults

### DIFF
--- a/neuralcompression/data/kodak.py
+++ b/neuralcompression/data/kodak.py
@@ -39,8 +39,7 @@ class Kodak(torch.utils.data.Dataset):
         kodak_url: URL for downloading public images.
             Defaults to http://r0k.us/graphics/kodak/kodak/.
         transform: callable object for transforming the
-            loaded images. If ``None``, defaults to
-            ``torchvision.transforms.ToTensor``.
+            loaded images.
     """
 
     def __init__(
@@ -54,7 +53,7 @@ class Kodak(torch.utils.data.Dataset):
     ):
         self.root = Path(root)
         self.im_list = []
-        self.transform = ToTensor() if transform is None else transform
+        self.transform = transform
 
         self.im_list = [
             self.root / "kodim{:02}.png".format(im_num)

--- a/neuralcompression/data/kodak.py
+++ b/neuralcompression/data/kodak.py
@@ -14,6 +14,7 @@ from typing import Any, Callable, Optional, Union
 import torch
 from torch import Tensor
 from torchvision.datasets.folder import default_loader
+from torchvision.transforms.transforms import ToTensor
 from tqdm import tqdm
 
 NUM_IMAGES = 24
@@ -27,18 +28,19 @@ class Kodak(torch.utils.data.Dataset):
 
     Args:
         root: base directory for data set.
-        check_hash: if True, checks the sha1 hash of root at
+        check_hash: if ``True``, checks the sha1 hash of root at
             initialization time to make sure files were downloaded correctly.
-        download: if True, downloads the dataset from the
+        download: if ``True``, downloads the dataset from the
             internet and puts it in root directory.
-        force_download: if True and download=True, will download the dataset
-            even if the root directory already exists. If False, an error
-            will be thrown if download=True but the root directory already
-            exists.
+        force_download: if ``True`` and ``download=True``, will download
+            the dataset even if the root directory already exists.
+            If ``False``, an error will be thrown if ``download=True``
+            but the root directory already exists.
         kodak_url: URL for downloading public images.
             Defaults to http://r0k.us/graphics/kodak/kodak/.
         transform: callable object for transforming the
-            loaded images.
+            loaded images. If ``None``, defaults to
+            ``torchvision.transforms.ToTensor``.
     """
 
     def __init__(
@@ -52,7 +54,7 @@ class Kodak(torch.utils.data.Dataset):
     ):
         self.root = Path(root)
         self.im_list = []
-        self.transform = transform
+        self.transform = ToTensor() if transform is None else transform
 
         self.im_list = [
             self.root / "kodim{:02}.png".format(im_num)

--- a/neuralcompression/data/kodak.py
+++ b/neuralcompression/data/kodak.py
@@ -14,7 +14,6 @@ from typing import Any, Callable, Optional, Union
 import torch
 from torch import Tensor
 from torchvision.datasets.folder import default_loader
-from torchvision.transforms.transforms import ToTensor
 from tqdm import tqdm
 
 NUM_IMAGES = 24

--- a/neuralcompression/data/vimeo90k.py
+++ b/neuralcompression/data/vimeo90k.py
@@ -28,22 +28,28 @@ class Vimeo90kSeptuplet(torch.utils.data.Dataset):
     Args:
         root: Path to the Vimeo-90k root directory (i.e. the
             directory containing the dataset's README).
-        as_video: Determines whether the dataset should return individual images
-            (as_video=False) or multiple consecutive frames (as_video=True) at
-            a time.
-        frames_per_group: The number of frames to include from each septuplet.
-            Specifically, the first frames_per_group frames from each septuplet
-            are included in the dataset. Must be between 1 and 7.
+        as_video: Determines whether the dataset should return
+            individual images (``as_video=False``) or
+            multiple consecutive frames  (``as_video=True``)
+            at a time.
+        frames_per_group: The number of frames to include from
+            each septuplet. Specifically, the first ``frames_per_group``
+            frames from each septuplet are included in
+            the dataset. Must be between 1 and 7.
         split: Specifies which dataset parition should be used. Valid values
-            are "train" or "test". Exactly one of ``split`` or
+            are ``"train"`` or ``"test"``. Exactly one of ``split`` or
             'folder_list' must be specified.
         folder_list: A list of paths to septuplets to include in the dataset
             split. Each septuplet path must be a directory containing the files
-            im1.png, ..., im7.png. Exactly one of ``split`` or
+            ``im1.png``, ..., ``im7.png``. Exactly one of ``split`` or
             ``folder_list`` must be specified.
         pil_transform: Callable object for applying transforms to
             the PIL images prior to image concatenation. If using, be sure to
             have the final operation convert the PIL image to a tensor.
+            Following ``torchvision``'s dataset conventions, the default
+            transform is ``torchvision.transforms.ToTensor`` when
+            in video mode (i.e. when ``as_video=True``), while no
+            default transform is applied in image mode.
         tensor_transform: Callable object for applying PyTorch
             transforms after data conversion and septuplet concatenation.
     """
@@ -68,7 +74,9 @@ class Vimeo90kSeptuplet(torch.utils.data.Dataset):
             )
 
         self.frames_per_group = frames_per_group
-        self.pil_transform = ToTensor() if pil_transform is None else pil_transform
+        self.pil_transform = (
+            ToTensor() if pil_transform is None and as_video else pil_transform
+        )
         self.tensor_transform = tensor_transform
 
         if (split is None) == (folder_list is None):

--- a/neuralcompression/data/vimeo90k.py
+++ b/neuralcompression/data/vimeo90k.py
@@ -25,6 +25,12 @@ class Vimeo90kSeptuplet(torch.utils.data.Dataset):
     Xue, Tianfan, et al. "Video enhancement with task-oriented flow."
     International Journal of Computer Vision 127.8 (2019): 1106-1125.
 
+    Note:
+        Following the conventions of ``torchvision``, in video mode this
+        dataset will have a default transform of
+        ``torchvision.transforms.ToTensor``, while in image mode no default
+        transform is provided.
+
     Args:
         root: Path to the Vimeo-90k root directory (i.e. the
             directory containing the dataset's README).

--- a/tests/test_vimeo_90k.py
+++ b/tests/test_vimeo_90k.py
@@ -86,7 +86,7 @@ def test_image_mode(tmp_path: Path, frames_per_group: int):
         as_video=False,
         frames_per_group=frames_per_group,
         split="test",
-        pil_transform=None,
+        pil_transform=ToTensor(),
         tensor_transform=lambda t: 5 * t,
     )
 


### PR DESCRIPTION
Changes our vimeo90k dataset so that in image mode the default transform is nothing, while in video mode the default is `torchvision.transforms.ToTensor`. This is consistent with the behaviour of the datasets in torchvision. I've also cleaned up some of the docs in both the Kodak and Vimeo datasets.