### PR TITLE
Forcing scale hyperprior compression to be on the CPU by default

### DIFF
--- a/neuralcompression/models/scale_hyperprior.py
+++ b/neuralcompression/models/scale_hyperprior.py
@@ -401,7 +401,7 @@ class ScaleHyperprior(nn.Module):
             cpu = torch.device("cpu")
             if param.device != cpu:
                 raise ValueError(
-                    f"Trying to compress/decompress on a GPU - "
+                    "Trying to compress/decompress on a GPU - "
                     "this has known numerical and reproducability issues "
                     "with the default entropy bottleneck implementation. "
                     "Either move your model to the CPU or pass "

--- a/neuralcompression/models/scale_hyperprior.py
+++ b/neuralcompression/models/scale_hyperprior.py
@@ -395,8 +395,8 @@ class ScaleHyperprior(nn.Module):
         return image_bottleneck_updated | hyper_bottleneck_updated
 
     def _on_cpu(self):
+        cpu = torch.device("cpu")
         for param in self.parameters():
-            cpu = torch.device("cpu")
             if param.device != cpu:
                 return False
         return True

--- a/neuralcompression/models/scale_hyperprior.py
+++ b/neuralcompression/models/scale_hyperprior.py
@@ -483,7 +483,7 @@ class ScaleHyperprior(nn.Module):
             reconstruction: Tensor of shape [batch, channels, height, width].
         """
         if not self._on_cpu() and force_cpu:
-            raise ValueError("Compress not supported on GPU.")
+            raise ValueError("Decompress not supported on GPU.")
 
         hyper_latent_decoded = self.hyper_bottleneck.decompress(  # type: ignore
             hyper_latent_strings, hyper_latent_shape


### PR DESCRIPTION
This PR raises an error in the scale hyperprior model when trying to perform compression/decompression with the model placed on the GPU, since inference on the GPU can lead to numerical/reproducibility issues. This behaviour can be turned off with the `force_cpu` flag I added.