### PR TITLE
Install neuralcompression from github instead of pypi in flop counter notebook

### DIFF
--- a/tutorials/Flop_Count_Example.ipynb
+++ b/tutorials/Flop_Count_Example.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install neuralcompression"
+    "!pip install git+https://github.com/facebookresearch/NeuralCompression/"
    ]
   },
   {


### PR DESCRIPTION
The latest version of `neuralcompression` on pypi predates the addition of the flop counter - this fix makes sure that the package version installed in the tutorial is up to date enough to include the counter.