### PR TITLE
Add docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 sphinx>=3.2.0
 pytorch-sphinx-theme>=0.0.19
 sphinxcontrib-katex
+sphinx-copybutton
 sphinx-autodoc-typehints
 pillow>=6.2.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+sphinx>=3.2.0
+pytorch-sphinx-theme>=0.0.19
+sphinxcontrib-katex
+sphinx-autodoc-typehints

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 sphinx>=3.2.0
 pytorch-sphinx-theme>=0.0.19
-sphinxcontrib-katex
-sphinx-copybutton
-sphinx-autodoc-typehints
+sphinxcontrib-katex>=0.8.6
+sphinx-copybutton>=0.4.0
+sphinx-autodoc-typehints>=1.12.0
 pillow>=6.2.0
+pytorch_sphinx_theme@git+https://github.com/pytorch/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ sphinx>=3.2.0
 pytorch-sphinx-theme>=0.0.19
 sphinxcontrib-katex
 sphinx-autodoc-typehints
+pillow>=6.2.0


### PR DESCRIPTION
This adds a `requirements.txt` to help ReadTheDocs build the package documentation. The live site for this branch can be seen here: https://neuralcompression.readthedocs.io/en/mmuckley-add_docs_requirements/