### PR TITLE
Update triggers for CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,7 +1,13 @@
 name: Build and Test
 
 # trigger on any PR or push to main
-on: [push, pull_request]
+# also allow manual triggering
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
This PR alters the triggers for continuous integration. Previously, we triggered all tests on both pushes and pull requests. This meant that within a PR we would have "duplicate" (but not really duplicate) checks. What we really want on a PR is just the PR check, so we'll keep that.

The other thing that's nice to have is to trigger CI when pushing to a branch. That is what this PR will remove, but to replace it we add `workflow_dispatch` which allows a user to trigger CI with the GitHub UI. So we remove quite a bit of duplicated tests at the cost of making users click a button if they want to test their code before PR.

Note that this PR only applies to people who push to branches of the repository.