### PR TITLE
Update docs landing page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
-torchvision
-===========
+NeuralCompression
+=================
 
 The :mod:`neuralcompression` package consists of datasets, metrics, and models
 for data compression.


### PR DESCRIPTION
Updates the docs landing page so we stop saying we're `torchvision`.

## Changes

Updates landing page.

## Testing

No tests.

## References

No references.
