### PR TITLE
Update PyTorch to 1.10.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,9 +61,9 @@ install_requires =
     lpips~=0.1.4
     pillow~=8.4.0
     pytorchvideo~=0.1.3
-    torch==1.9.1
+    torch==1.10.0
     torchmetrics~=0.5.1
-    torchvision==0.10.1
+    torchvision==0.11.1
     tqdm~=4.62.3
 packages = find:
 python_requires = >=3.7

--- a/tests/distributions/test_uniform_noise.py
+++ b/tests/distributions/test_uniform_noise.py
@@ -24,13 +24,13 @@ class TestUniformNoise:
     x = torch.normal(0.0, 1.0, (32,), generator=generator)
 
     def test_cdf(self):
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             UniformNoise(self.distribution).cdf(self.x),
             self.distribution.cdf(self.x),
         )
 
     def test_entropy(self):
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             UniformNoise(self.distribution).entropy(),
             self.distribution.entropy(),
         )
@@ -40,61 +40,61 @@ class TestUniformNoise:
             UniformNoise(self.distribution).enumerate_support()
 
     def test_expand(self):
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             UniformNoise(self.distribution).expand(Size([32])).batch_shape,
             Size([32]),
         )
 
     def test_icdf(self):
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             UniformNoise(self.distribution).icdf(self.x).shape,
             torch.Size([32]),
         )
 
     def test_log_cdf(self):
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             UniformNoise(self.distribution).log_cdf(self.x),
             ncF.log_cdf(self.x, self.distribution),
         )
 
     def test_log_prob(self):
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             UniformNoise(self.distribution).log_prob(self.x).shape,
             torch.Size([32]),
         )
 
     def test_log_survival_function(self):
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             UniformNoise(self.distribution).log_survival_function(self.x),
             ncF.log_survival_function(self.x, self.distribution),
         )
 
     def test_lower_tail(self):
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             UniformNoise(self.distribution).lower_tail(1.0),
             ncF.lower_tail(self.distribution, 1.0),
         )
 
     def test_mean(self):
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             UniformNoise(self.distribution).mean,
             torch.tensor(0.0),
         )
 
     def test_prob(self):
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             UniformNoise(self.distribution).prob(self.x).shape,
             torch.Size([32]),
         )
 
     def test_quantization_offset(self):
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             UniformNoise(self.distribution).quantization_offset,
             torch.tensor(0.0),
         )
 
     def test_rsample(self):
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             UniformNoise(self.distribution).rsample(torch.Size((5, 4))).shape,
             torch.Size([5, 4]),
         )
@@ -103,19 +103,19 @@ class TestUniformNoise:
         assert UniformNoise(self.distribution).support == self.distribution.support
 
     def test_survival_function(self):
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             UniformNoise(self.distribution).survival_function(self.x),
             ncF.survival_function(self.x, self.distribution),
         )
 
     def test_upper_tail(self):
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             UniformNoise(self.distribution).upper_tail(1.0),
             ncF.upper_tail(self.distribution, 1.0),
         )
 
     def test_variance(self):
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             UniformNoise(self.distribution).variance,
             torch.tensor(1.0),
         )

--- a/tests/functional/test_lower_bound.py
+++ b/tests/functional/test_lower_bound.py
@@ -24,7 +24,7 @@ def test_lower_bound():
 
     y = lower_bound(x, bound)
 
-    torch.testing.assert_equal(
+    torch.testing.assert_close(
         y,
         torch.max(x, bound),
     )

--- a/tests/functional/test_ndtr.py
+++ b/tests/functional/test_ndtr.py
@@ -14,7 +14,7 @@ from neuralcompression.functional import ndtr
 
 
 def test_ndtr():
-    torch.testing.assert_equal(
+    torch.testing.assert_close(
         ndtr(torch.tensor([0.0])),
         torch.tensor([0.5]),
     )

--- a/tests/layers/test_continuous_entropy.py
+++ b/tests/layers/test_continuous_entropy.py
@@ -130,15 +130,15 @@ class TestContinuousEntropy:
             maximum_cdf_size=self.maximum_cdf_size,
         )
 
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             continuous_entropy._cdfs, torch.zeros((1, 16)).to(torch.int32)
         )
 
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             continuous_entropy._cdf_sizes, torch.zeros((16,)).to(torch.int32)
         )
 
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             continuous_entropy._cdf_offsets, torch.zeros((16,)).to(torch.int32)
         )
 
@@ -148,17 +148,17 @@ class TestContinuousEntropy:
             prior=self.prior,
         )
 
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             continuous_entropy._cdfs.shape,
             Size([16, 6]),
         )
 
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             continuous_entropy._cdf_sizes.shape,
             Size([16]),
         )
 
-        torch.testing.assert_equal(
+        torch.testing.assert_close(
             continuous_entropy._cdf_offsets.shape,
             Size([16]),
         )


### PR DESCRIPTION
Closes #127.

## Changes

- [x] Replaced `torch.testing.assert_equal` with `torch.testing.assert_close`
- [x] Updates `torch` to 1.10.0
- [x] Updates `torchvision` to 0.11.1