### PR TITLE
Replace license docstrings with comments

### DIFF
--- a/docs/examples/plot_example.py
+++ b/docs/examples/plot_example.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """
 This is my example script
 =========================

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # Configuration file for the Sphinx documentation builder.
 #

--- a/neuralcompression/__init__.py
+++ b/neuralcompression/__init__.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 __version__ = "0.1.1a20210720"
 __author__ = "Facebook AI Research"

--- a/neuralcompression/data/__init__.py
+++ b/neuralcompression/data/__init__.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from ._clic_2020_image import CLIC2020Image
 from ._clic_2020_video import CLIC2020Video

--- a/neuralcompression/data/_clic_2020_image.py
+++ b/neuralcompression/data/_clic_2020_image.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import os
 import os.path

--- a/neuralcompression/data/_clic_2020_video.py
+++ b/neuralcompression/data/_clic_2020_video.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import concurrent.futures
 import functools

--- a/neuralcompression/data/kodak.py
+++ b/neuralcompression/data/kodak.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import hashlib
 import shutil

--- a/neuralcompression/data/vimeo90k.py
+++ b/neuralcompression/data/vimeo90k.py
@@ -1,9 +1,8 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
 import os
 from pathlib import Path
 from typing import Any, Callable, Optional, Sequence, Union

--- a/neuralcompression/distributions/__init__.py
+++ b/neuralcompression/distributions/__init__.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from ._noisy_normal import NoisyNormal
 from ._uniform_noise import UniformNoise

--- a/neuralcompression/distributions/_noisy_normal.py
+++ b/neuralcompression/distributions/_noisy_normal.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Union
 

--- a/neuralcompression/distributions/_uniform_noise.py
+++ b/neuralcompression/distributions/_uniform_noise.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Any, Dict, Optional
 

--- a/neuralcompression/entropy_coders/__init__.py
+++ b/neuralcompression/entropy_coders/__init__.py
@@ -1,8 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
 from . import craystack
 from . import jax_arithemetic_coder as jac

--- a/neuralcompression/entropy_coders/craystack/__init__.py
+++ b/neuralcompression/entropy_coders/craystack/__init__.py
@@ -1,9 +1,8 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
 from ._backend import (
     CrayCompressedMessage,
     array_to_craymessage,

--- a/neuralcompression/entropy_coders/craystack/_backend.py
+++ b/neuralcompression/entropy_coders/craystack/_backend.py
@@ -1,34 +1,33 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Copyright (c) 2021 Jamie Townsend
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 """
-Portions Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-
-MIT License
-
-Copyright (c) 2021 Jamie Townsend
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
 Code modified from
 https://github.com/j-towns/crayjax
 """
+
 from typing import NamedTuple, Sequence, Tuple
 
 import jax.lax as lax

--- a/neuralcompression/entropy_coders/craystack/codecs.py
+++ b/neuralcompression/entropy_coders/craystack/codecs.py
@@ -1,9 +1,8 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
 from typing import Callable, NamedTuple, Optional, Sequence, Tuple
 
 import jax.lax as lax

--- a/neuralcompression/entropy_coders/craystack/coder.py
+++ b/neuralcompression/entropy_coders/craystack/coder.py
@@ -1,9 +1,8 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
 from typing import Optional, Sequence, Tuple
 
 import jax

--- a/neuralcompression/entropy_coders/jax_arithemetic_coder.py
+++ b/neuralcompression/entropy_coders/jax_arithemetic_coder.py
@@ -1,12 +1,13 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-
 This implementation is based on the blog post at
 https://marknelson.us/posts/2014/10/19/data-compression-with-arithmetic-coding.html
 """
+
 from typing import Any, Callable, List, Tuple
 
 import jax

--- a/neuralcompression/ext/__init__.py
+++ b/neuralcompression/ext/__init__.py
@@ -1,1 +1,6 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from ._pmf_to_quantized_cdf import pmf_to_quantized_cdf

--- a/neuralcompression/functional/__init__.py
+++ b/neuralcompression/functional/__init__.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from ._estimate_tails import estimate_tails
 from ._log_cdf import log_cdf

--- a/neuralcompression/functional/_estimate_tails.py
+++ b/neuralcompression/functional/_estimate_tails.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import typing
 

--- a/neuralcompression/functional/_log_cdf.py
+++ b/neuralcompression/functional/_log_cdf.py
@@ -1,8 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 from torch import Tensor

--- a/neuralcompression/functional/_log_expm1.py
+++ b/neuralcompression/functional/_log_expm1.py
@@ -1,8 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 from torch import Tensor

--- a/neuralcompression/functional/_log_ndtr.py
+++ b/neuralcompression/functional/_log_ndtr.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import math
 

--- a/neuralcompression/functional/_log_survival_function.py
+++ b/neuralcompression/functional/_log_survival_function.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 from torch import Tensor

--- a/neuralcompression/functional/_lower_bound.py
+++ b/neuralcompression/functional/_lower_bound.py
@@ -1,8 +1,8 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 import enum
 from enum import IntEnum
 from typing import Union

--- a/neuralcompression/functional/_lower_tail.py
+++ b/neuralcompression/functional/_lower_tail.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import math
 

--- a/neuralcompression/functional/_ndtr.py
+++ b/neuralcompression/functional/_ndtr.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import math
 

--- a/neuralcompression/functional/_pmf_to_quantized_cdf.py
+++ b/neuralcompression/functional/_pmf_to_quantized_cdf.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 from torch import Tensor

--- a/neuralcompression/functional/_quantization_offset.py
+++ b/neuralcompression/functional/_quantization_offset.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 from torch import Tensor

--- a/neuralcompression/functional/_soft_round/__init__.py
+++ b/neuralcompression/functional/_soft_round/__init__.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from ._soft_round import soft_round
 from ._soft_round_conditional_mean import soft_round_conditional_mean
 from ._soft_round_inverse import soft_round_inverse

--- a/neuralcompression/functional/_soft_round/_soft_round.py
+++ b/neuralcompression/functional/_soft_round/_soft_round.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 

--- a/neuralcompression/functional/_soft_round/_soft_round_conditional_mean.py
+++ b/neuralcompression/functional/_soft_round/_soft_round_conditional_mean.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 

--- a/neuralcompression/functional/_soft_round/_soft_round_inverse.py
+++ b/neuralcompression/functional/_soft_round/_soft_round_inverse.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 

--- a/neuralcompression/functional/_survival_function.py
+++ b/neuralcompression/functional/_survival_function.py
@@ -1,8 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 from torch import Tensor

--- a/neuralcompression/functional/_upper_tail.py
+++ b/neuralcompression/functional/_upper_tail.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import math
 

--- a/neuralcompression/functional/complexity.py
+++ b/neuralcompression/functional/complexity.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from copy import copy
 from typing import Any, Dict, Optional, Sequence, Tuple

--- a/neuralcompression/functional/distortion.py
+++ b/neuralcompression/functional/distortion.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Callable, Optional, Sequence
 

--- a/neuralcompression/functional/information.py
+++ b/neuralcompression/functional/information.py
@@ -1,9 +1,8 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
 import math
 
 import torch

--- a/neuralcompression/functional/visualize.py
+++ b/neuralcompression/functional/visualize.py
@@ -1,9 +1,8 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
 import math
 
 import torch

--- a/neuralcompression/functional/warp.py
+++ b/neuralcompression/functional/warp.py
@@ -1,9 +1,8 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
 from typing import Optional
 
 import torch

--- a/neuralcompression/layers/__init__.py
+++ b/neuralcompression/layers/__init__.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from ._analysis_transformation_2d import AnalysisTransformation2D
 from ._continuous_entropy import ContinuousEntropy

--- a/neuralcompression/layers/_analysis_transformation_2d.py
+++ b/neuralcompression/layers/_analysis_transformation_2d.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from torch import Tensor
 from torch.nn import Conv2d, Module, Sequential

--- a/neuralcompression/layers/_continuous_entropy.py
+++ b/neuralcompression/layers/_continuous_entropy.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import abc
 from typing import Optional, Tuple, Union

--- a/neuralcompression/layers/_generalized_divisive_normalization.py
+++ b/neuralcompression/layers/_generalized_divisive_normalization.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import functools
 from typing import Callable, Optional

--- a/neuralcompression/layers/_hyper_analysis_transformation_2d.py
+++ b/neuralcompression/layers/_hyper_analysis_transformation_2d.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from torch import Tensor
 from torch.nn import Conv2d, Module, ReLU, Sequential

--- a/neuralcompression/layers/_hyper_synthesis_transformation_2d.py
+++ b/neuralcompression/layers/_hyper_synthesis_transformation_2d.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from torch import Tensor
 from torch.nn import Conv2d, ConvTranspose2d, Module, ReLU, Sequential

--- a/neuralcompression/layers/_non_negative_parameterization.py
+++ b/neuralcompression/layers/_non_negative_parameterization.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Optional, Tuple
 

--- a/neuralcompression/layers/_synthesis_transformation_2d.py
+++ b/neuralcompression/layers/_synthesis_transformation_2d.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from torch import Tensor
 from torch.nn import ConvTranspose2d, Module, Sequential
 

--- a/neuralcompression/layers/gdn.py
+++ b/neuralcompression/layers/gdn.py
@@ -1,9 +1,8 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
 import torch
 import torch.nn as nn
 import torch.nn.functional as F

--- a/neuralcompression/metrics/__init__.py
+++ b/neuralcompression/metrics/__init__.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from .distortion import (
     LearnedPerceptualImagePatchSimilarity,

--- a/neuralcompression/metrics/distortion.py
+++ b/neuralcompression/metrics/distortion.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import Any, Callable, Optional, Sequence
 

--- a/neuralcompression/models/__init__.py
+++ b/neuralcompression/models/__init__.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from ._hific import HiFiCDiscriminator, HiFiCEncoder, HiFiCGenerator
 from .deep_video_compression import DVC

--- a/neuralcompression/models/_hific/__init__.py
+++ b/neuralcompression/models/_hific/__init__.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from ._hific_discriminator import HiFiCDiscriminator
 from ._hific_encoder import HiFiCEncoder

--- a/neuralcompression/models/_hific/_channel_norm_2d.py
+++ b/neuralcompression/models/_hific/_channel_norm_2d.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 import torch.nn

--- a/neuralcompression/models/_hific/_hific_discriminator.py
+++ b/neuralcompression/models/_hific/_hific_discriminator.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import typing
 

--- a/neuralcompression/models/_hific/_hific_encoder.py
+++ b/neuralcompression/models/_hific/_hific_encoder.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import typing
 

--- a/neuralcompression/models/_hific/_hific_generator.py
+++ b/neuralcompression/models/_hific/_hific_generator.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import typing
 

--- a/neuralcompression/models/_hific/_least_squares_adversarial_loss.py
+++ b/neuralcompression/models/_hific/_least_squares_adversarial_loss.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import typing
 

--- a/neuralcompression/models/_hific/_non_saturating_adversarial_loss.py
+++ b/neuralcompression/models/_hific/_non_saturating_adversarial_loss.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import typing
 

--- a/neuralcompression/models/_hific/_weighted_rate_loss.py
+++ b/neuralcompression/models/_hific/_weighted_rate_loss.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import typing
 

--- a/neuralcompression/models/deep_video_compression.py
+++ b/neuralcompression/models/deep_video_compression.py
@@ -1,9 +1,9 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 """
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-
 Code is based on the papers:
 
 Lu, Guo, et al. "DVC: An end-to-end deep video compression framework."

--- a/neuralcompression/models/scale_hyperprior.py
+++ b/neuralcompression/models/scale_hyperprior.py
@@ -1,23 +1,21 @@
-"""
-Portions Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-
-Copyright 2020 InterDigital Communications, Inc.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+# Copyright 2020 InterDigital Communications, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from typing import Dict, List, Optional, Sequence, Tuple
 

--- a/projects/deep_video_compression/_utils.py
+++ b/projects/deep_video_compression/_utils.py
@@ -1,9 +1,8 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
 from typing import Callable, NamedTuple, Optional
 
 import torch

--- a/projects/deep_video_compression/data_module.py
+++ b/projects/deep_video_compression/data_module.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 from typing import Optional, Sequence, Union
 
 from pytorch_lightning import LightningDataModule

--- a/projects/deep_video_compression/dvc_module.py
+++ b/projects/deep_video_compression/dvc_module.py
@@ -1,9 +1,8 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
 from typing import NamedTuple, Optional, Tuple
 
 import torch

--- a/projects/deep_video_compression/train.py
+++ b/projects/deep_video_compression/train.py
@@ -1,9 +1,8 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
 from pathlib import Path
 
 import hydra

--- a/projects/scale_hyperprior_lightning/scale_hyperprior.py
+++ b/projects/scale_hyperprior_lightning/scale_hyperprior.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import math
 from typing import List, Sequence, Tuple

--- a/projects/scale_hyperprior_lightning/tests/test_scale_hyperprior_lightning.py
+++ b/projects/scale_hyperprior_lightning/tests/test_scale_hyperprior_lightning.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import pytest
 import torch

--- a/projects/scale_hyperprior_lightning/train.py
+++ b/projects/scale_hyperprior_lightning/train.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
 

--- a/projects/scale_hyperprior_lightning/vimeo.py
+++ b/projects/scale_hyperprior_lightning/vimeo.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from typing import List, Optional, Sequence, Union
 

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
 

--- a/tests/distributions/__init__.py
+++ b/tests/distributions/__init__.py
@@ -1,6 +1,4 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/tests/distributions/test_noisy_normal.py
+++ b/tests/distributions/test_noisy_normal.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 from torch.distributions import Normal
 

--- a/tests/distributions/test_uniform_noise.py
+++ b/tests/distributions/test_uniform_noise.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import pytest
 import torch.testing

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/tests/functional/test_estimate_tails.py
+++ b/tests/functional/test_estimate_tails.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import math
 import random

--- a/tests/functional/test_log_cdf.py
+++ b/tests/functional/test_log_cdf.py
@@ -1,8 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import numpy.random
 import scipy.special

--- a/tests/functional/test_log_expm1.py
+++ b/tests/functional/test_log_expm1.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import numpy.random
 import torch

--- a/tests/functional/test_log_ndtr.py
+++ b/tests/functional/test_log_ndtr.py
@@ -1,8 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import numpy.random
 import scipy.special

--- a/tests/functional/test_log_survival_function.py
+++ b/tests/functional/test_log_survival_function.py
@@ -1,8 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import numpy
 import scipy.stats

--- a/tests/functional/test_lower_bound.py
+++ b/tests/functional/test_lower_bound.py
@@ -1,8 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 import torch.testing

--- a/tests/functional/test_lower_tail.py
+++ b/tests/functional/test_lower_tail.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 import torch.testing

--- a/tests/functional/test_ndtr.py
+++ b/tests/functional/test_ndtr.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import numpy.random
 import scipy.special

--- a/tests/functional/test_pmf_to_quantized_cdf.py
+++ b/tests/functional/test_pmf_to_quantized_cdf.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import pytest
 import torch

--- a/tests/functional/test_quantization_offset.py
+++ b/tests/functional/test_quantization_offset.py
@@ -1,3 +1,8 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from torch.distributions import Gamma, Laplace, Normal
 
 from neuralcompression.functional import quantization_offset

--- a/tests/functional/test_soft_round.py
+++ b/tests/functional/test_soft_round.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 

--- a/tests/functional/test_soft_round_conditional_mean.py
+++ b/tests/functional/test_soft_round_conditional_mean.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 

--- a/tests/functional/test_soft_round_inverse.py
+++ b/tests/functional/test_soft_round_inverse.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 

--- a/tests/functional/test_survival_function.py
+++ b/tests/functional/test_survival_function.py
@@ -1,8 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import numpy
 import scipy.stats

--- a/tests/functional/test_upper_tail.py
+++ b/tests/functional/test_upper_tail.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 import torch.testing

--- a/tests/layers/__init__.py
+++ b/tests/layers/__init__.py
@@ -1,6 +1,4 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.

--- a/tests/layers/test_analysis_transformation_2d.py
+++ b/tests/layers/test_analysis_transformation_2d.py
@@ -1,8 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 from torch import Size

--- a/tests/layers/test_continuous_entropy.py
+++ b/tests/layers/test_continuous_entropy.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import pytest
 import torch

--- a/tests/layers/test_generalized_divisive_normalization.py
+++ b/tests/layers/test_generalized_divisive_normalization.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 import torch.testing

--- a/tests/layers/test_hyper_analysis_transformation_2d.py
+++ b/tests/layers/test_hyper_analysis_transformation_2d.py
@@ -1,8 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 from torch import Size

--- a/tests/layers/test_hyper_synthesis_transformation_2d.py
+++ b/tests/layers/test_hyper_synthesis_transformation_2d.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 from torch import Size

--- a/tests/layers/test_non_negative_parameterization.py
+++ b/tests/layers/test_non_negative_parameterization.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 import torch.testing

--- a/tests/layers/test_synthesis_transformation_2d.py
+++ b/tests/layers/test_synthesis_transformation_2d.py
@@ -1,8 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 from torch import Size

--- a/tests/models/_hific/test_hific_discriminator.py
+++ b/tests/models/_hific/test_hific_discriminator.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 

--- a/tests/models/_hific/test_hific_encoder.py
+++ b/tests/models/_hific/test_hific_encoder.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 

--- a/tests/models/_hific/test_hific_generator.py
+++ b/tests/models/_hific/test_hific_generator.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import torch
 

--- a/tests/test_clic_2020_image.py
+++ b/tests/test_clic_2020_image.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import numpy
 import pytest

--- a/tests/test_clic_2020_video.py
+++ b/tests/test_clic_2020_video.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import random
 

--- a/tests/test_complexity.py
+++ b/tests/test_complexity.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import pytest
 import torch

--- a/tests/test_distortion.py
+++ b/tests/test_distortion.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import pytest
 import tensorflow as tf

--- a/tests/test_entropy_coders.py
+++ b/tests/test_entropy_coders.py
@@ -1,9 +1,8 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
 import jax.numpy as jnp
 import numpy as np
 import pytest

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,9 +1,8 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
 import cv2
 import numpy as np
 import pytest

--- a/tests/test_kodak.py
+++ b/tests/test_kodak.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import numpy as np
 import pytest

--- a/tests/test_layers_gdn.py
+++ b/tests/test_layers_gdn.py
@@ -1,9 +1,8 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
 import pytest
 import torch
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,9 +1,8 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
 import numpy as np
 import pytest
 import torch

--- a/tests/test_scale_hyperprior.py
+++ b/tests/test_scale_hyperprior.py
@@ -1,9 +1,7 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
-
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 import pytest
 import torch

--- a/tests/test_vimeo_90k.py
+++ b/tests/test_vimeo_90k.py
@@ -1,9 +1,8 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
 from pathlib import Path
 
 import numpy as np

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,8 @@
-"""
-Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-This source code is licensed under the MIT license found in the
-LICENSE file in the root directory of this source tree.
-"""
 import PIL
 import numpy
 import numpy as np


### PR DESCRIPTION
The intention was three-fold:

1. consolidate copyright formatting across `.py` sources
2. simplify the implementation of #100
3. remove copyright headers from module documentation

## Changes

- [x] replaces license docstrings with comments