### PR TITLE
remove metadata from __init__.py

### DIFF
--- a/neuralcompression/__init__.py
+++ b/neuralcompression/__init__.py
@@ -3,10 +3,4 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-__version__ = "0.1.1a20210720"
-__author__ = "Facebook AI Research"
-__license__ = "MIT"
-__homepage__ = ""
-__docs__ = "A collection of tools for neural compression enthusiasts."
-
 from . import data, entropy_coders, functional, layers, metrics, models


### PR DESCRIPTION
## Changes

The metadata special variables from `neuralcompression.__init__` were removed. 

This metadata was not currently used and is now available from `setup.cfg`
