### PR TITLE
Dependency and Build Fixes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 4
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.8]
 
     runs-on: ${{ matrix.platform }}
 
@@ -30,7 +30,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade wheel
-          pip install -e .
+          python setup.py bdist_wheel
+          pip install dist/*.whl
       - name: Test Import
         run: |
           python -c 'import neuralcompression'
@@ -41,7 +42,7 @@ jobs:
       max-parallel: 4
       matrix:
         platform: [ubuntu-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.8]
 
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -77,7 +77,7 @@ jobs:
           flake8 --version
           flake8 neuralcompression tests projects
           isort --version
-          isort neuralcompression tests projects
+          isort --check-only neuralcompression tests projects
       - name: Install NeuralCompression
         run: |
           python setup.py bdist_wheel

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include *.md
+include *.cc
 include LICENSE
 include pyproject.toml
 include setup.py

--- a/neuralcompression/__init__.py
+++ b/neuralcompression/__init__.py
@@ -2,3 +2,13 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("neuralcompression")
+except PackageNotFoundError:
+    # package is not installed
+    import warnings
+
+    warnings.warn("Could not retrieve neuralcompression version!")

--- a/neuralcompression/ext/__init__.py
+++ b/neuralcompression/ext/__init__.py
@@ -5,13 +5,15 @@
 
 from pathlib import Path
 
-from torch.utils.cpp_extension import load
+from ._extension_loader import load_extension
 
-print(str(Path(__file__).resolve().parent / "pmf_to_quantized_cdf_py.cc"))
-_pmf_to_quantized_cdf = load(
-    name="_pmf_to_quantized_cdf",
-    sources=[str(Path(__file__).resolve().parent / "pmf_to_quantized_cdf_py.cc")],
-    verbose=True,
+# load pmf_to_quantized_cdf
+_extension_folder = Path(__file__).resolve().parent
+_extension_name = "_pmf_to_quantized_cdf"
+_extension_files = ["pmf_to_quantized_cdf_py.cc"]
+
+_pmf_to_quantized_cdf = load_extension(
+    _extension_name, _extension_folder, _extension_files
 )
 
 from _pmf_to_quantized_cdf import pmf_to_quantized_cdf  # noqa: E402

--- a/neuralcompression/ext/__init__.py
+++ b/neuralcompression/ext/__init__.py
@@ -7,8 +7,10 @@ from torch.utils.cpp_extension import load
 from pathlib import Path
 
 print(str(Path(__file__).resolve().parent / "pmf_to_quantized_cdf_py.cc"))
-pmf_to_quantized_cdf = load(
-    name="pmf_to_quantized_cdf",
+_pmf_to_quantized_cdf = load(
+    name="_pmf_to_quantized_cdf",
     sources=[str(Path(__file__).resolve().parent / "pmf_to_quantized_cdf_py.cc")],
     verbose=True,
 )
+
+from _pmf_to_quantized_cdf import pmf_to_quantized_cdf

--- a/neuralcompression/ext/__init__.py
+++ b/neuralcompression/ext/__init__.py
@@ -3,8 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torch.utils.cpp_extension import load
 from pathlib import Path
+
+from torch.utils.cpp_extension import load
 
 print(str(Path(__file__).resolve().parent / "pmf_to_quantized_cdf_py.cc"))
 _pmf_to_quantized_cdf = load(

--- a/neuralcompression/ext/__init__.py
+++ b/neuralcompression/ext/__init__.py
@@ -13,4 +13,4 @@ _pmf_to_quantized_cdf = load(
     verbose=True,
 )
 
-from _pmf_to_quantized_cdf import pmf_to_quantized_cdf
+from _pmf_to_quantized_cdf import pmf_to_quantized_cdf  # noqa: E402

--- a/neuralcompression/ext/__init__.py
+++ b/neuralcompression/ext/__init__.py
@@ -3,4 +3,12 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from ._pmf_to_quantized_cdf import pmf_to_quantized_cdf
+from torch.utils.cpp_extension import load
+from pathlib import Path
+
+print(str(Path(__file__).resolve().parent / "pmf_to_quantized_cdf_py.cc"))
+pmf_to_quantized_cdf = load(
+    name="pmf_to_quantized_cdf",
+    sources=[str(Path(__file__).resolve().parent / "pmf_to_quantized_cdf_py.cc")],
+    verbose=True,
+)

--- a/neuralcompression/ext/_extension_loader.py
+++ b/neuralcompression/ext/_extension_loader.py
@@ -4,8 +4,9 @@
 # LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
-from torch.utils.cpp_extension import load
 from typing import List
+
+from torch.utils.cpp_extension import load
 
 
 def load_extension(extension_name: str, extension_folder: Path, file_names: List[str]):

--- a/neuralcompression/ext/_extension_loader.py
+++ b/neuralcompression/ext/_extension_loader.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from pathlib import Path
+from torch.utils.cpp_extension import load
+from typing import List
+
+
+def load_extension(extension_name: str, extension_folder: Path, file_names: List[str]):
+    """Simple extension loading utility."""
+    return load(
+        name=extension_name,
+        sources=[str(extension_folder / file_name) for file_name in file_names],
+        verbose=True,
+    )

--- a/neuralcompression/functional/_multiscale_structural_similarity.py
+++ b/neuralcompression/functional/_multiscale_structural_similarity.py
@@ -1,4 +1,4 @@
-from typing import Optional, Callable, Sequence
+from typing import Callable, Optional, Sequence
 
 import torch
 from torch import Tensor

--- a/neuralcompression/functional/_optical_flow_to_color.py
+++ b/neuralcompression/functional/_optical_flow_to_color.py
@@ -7,6 +7,7 @@ import math
 
 import torch
 from torch import Tensor
+
 from ._hsv_to_rgb import hsv_to_rgb
 
 

--- a/neuralcompression/metrics/distortion.py
+++ b/neuralcompression/metrics/distortion.py
@@ -8,8 +8,8 @@ from typing import Any, Callable, Optional, Sequence
 import torch
 from torchmetrics import Metric
 
-from neuralcompression.functional._lpips import _load_lpips_model
 from neuralcompression.functional import multiscale_structural_similarity
+from neuralcompression.functional._lpips import _load_lpips_model
 from neuralcompression.functional._multiscale_structural_similarity import (
     MS_SSIM_FACTORS,
 )

--- a/neuralcompression/models/_hyperprior_autoencoder.py
+++ b/neuralcompression/models/_hyperprior_autoencoder.py
@@ -16,6 +16,7 @@ from neuralcompression.layers import (
     HyperAnalysisTransformation2D,
     HyperSynthesisTransformation2D,
 )
+
 from ._prior_autoencoder import PriorAutoencoder
 
 

--- a/neuralcompression/models/_mean_scale_hyperprior_autoencoder.py
+++ b/neuralcompression/models/_mean_scale_hyperprior_autoencoder.py
@@ -10,6 +10,7 @@ from torch import Size, Tensor
 from torch.nn import Conv2d, ConvTranspose2d, LeakyReLU, Module, Sequential
 
 from neuralcompression.layers import HyperAnalysisTransformation2D
+
 from ._hyperprior_autoencoder import HyperpriorAutoencoder
 
 

--- a/projects/deep_video_compression/train.py
+++ b/projects/deep_video_compression/train.py
@@ -5,13 +5,12 @@
 
 from pathlib import Path
 
+import _optical_flow_to_color
 import hydra
 import numpy as np
 import pytorch_lightning as pl
 import torch
 import wandb
-
-import _optical_flow_to_color
 from data_module import Vimeo90kSeptupletLightning
 from dvc_module import DvcModule
 from omegaconf import DictConfig, OmegaConf

--- a/projects/variational_image_compression/lightning/_mean_scale_hyperprior_autoencoder.py
+++ b/projects/variational_image_compression/lightning/_mean_scale_hyperprior_autoencoder.py
@@ -6,6 +6,7 @@
 import torch.hub
 
 import neuralcompression.models
+
 from ._prior_autoencoder import _PriorAutoencoder
 
 

--- a/projects/variational_image_compression/lightning/_prior_autoencoder.py
+++ b/projects/variational_image_compression/lightning/_prior_autoencoder.py
@@ -4,14 +4,14 @@
 # LICENSE file in the root directory of this source tree.
 
 import math
-from typing import Any, Tuple, List
+from typing import Any, List, Tuple
 
 import torch
 import torch.nn.functional as F
 from compressai.entropy_models import EntropyBottleneck
 from pytorch_lightning import LightningModule
 from pytorch_lightning.utilities.types import EVAL_DATALOADERS, TRAIN_DATALOADERS
-from torch import Tensor, Size
+from torch import Size, Tensor
 from torch.optim import Adam
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 

--- a/projects/variational_image_compression/lightning/_scale_hyperprior_autoencoder.py
+++ b/projects/variational_image_compression/lightning/_scale_hyperprior_autoencoder.py
@@ -6,6 +6,7 @@
 import torch.hub
 
 import neuralcompression.models
+
 from ._prior_autoencoder import _PriorAutoencoder
 
 

--- a/projects/variational_image_compression/test/test_factorized_prior_autoencoder.py
+++ b/projects/variational_image_compression/test/test_factorized_prior_autoencoder.py
@@ -10,6 +10,7 @@ from torch.optim import Adam
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 
 import neuralcompression.models
+
 from ..lightning import FactorizedPriorAutoencoder
 
 

--- a/projects/variational_image_compression/test/test_mean_scale_hyperprior_autoencoder.py
+++ b/projects/variational_image_compression/test/test_mean_scale_hyperprior_autoencoder.py
@@ -10,6 +10,7 @@ from torch.optim import Adam
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 
 import neuralcompression.models
+
 from ..lightning import MeanScaleHyperpriorAutoencoder
 
 

--- a/projects/variational_image_compression/test/test_scale_hyperprior_autoencoder.py
+++ b/projects/variational_image_compression/test/test_scale_hyperprior_autoencoder.py
@@ -10,6 +10,7 @@ from torch.optim import Adam
 from torch.optim.lr_scheduler import ReduceLROnPlateau
 
 import neuralcompression.models
+
 from ..lightning import ScaleHyperpriorAutoencoder
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,6 @@ requires = [
 
 [tool.setuptools_scm]
 write_to = "neuralcompression/version.py"
+
+[isort]
+profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [options]
+include_package_data = True
 install_requires =
     compressai>=1.1.9
     fvcore>=0.1.5.post20211023
@@ -105,7 +106,7 @@ docs =
     sphinx>=4.3.1
 
 [options.package_data]
-*_=_*.cc
+* = *.cc
 
 [options.packages.find]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -104,6 +104,9 @@ docs =
     sphinxcontrib-katex>=0.8.6
     sphinx>=4.3.1
 
+[options.package_data]
+*_=_*.cc
+
 [options.packages.find]
 exclude =
     tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,41 +54,53 @@ ignore_missing_imports = True
 
 [options]
 install_requires =
-    compressai~=1.1.9
-    fvcore~=0.1.5.post20211023
-    jaxlib~=0.1.75
-    jax~=0.2.26
-    lpips~=0.1.4
-    pillow~=8.4.0
-    pytorch-lightning~=1.5.5
-    pytorchvideo~=0.1.3
-    torch==1.10.0
-    torchmetrics~=0.6.1
-    torchvision==0.11.1
-    tqdm~=4.62.3
+    compressai>=1.1.9
+    fvcore>=0.1.5.post20211023
+    h5py>=3.1.0
+    jaxlib>=0.1.75
+    jax>=0.2.26
+    lpips>=0.1.4
+    pillow>=8.4.0
+    pytorch-lightning>=1.5.5
+    pytorchvideo>=0.1.3
+    torch>=1.10.0
+    torchmetrics>=0.6.1
+    torchvision>=0.11.1
+    tqdm>=4.62.3
 packages = find:
 python_requires = >=3.7
 
 [options.extras_require]
 dev =
     black==21.12b0
+    compressai==1.1.9
     flake8==4.0.1
+    fvcore==0.1.5.post20211023
+    h5py==3.1.0
     isort==5.10.1
+    jaxlib==0.1.75
+    jax==0.2.26
+    lpips==0.1.4
     mypy==0.910
     opencv-python~=4.5.4.60
+    pillow==8.4.0
     pre-commit~=2.16.0
     pytest==6.2.5
+    pytorch-lightning==1.5.5
+    pytorchvideo==0.1.3
     tensorflow-addons~=0.15.0
     tensorflow~=2.7.0
+    torch==1.10.1
+    torchmetrics==0.6.1
+    torchvision==0.11.2
 docs =
-    myst-parser~=0.15.2
-    scikit-image~=0.19.0
-    sphinx-autodoc-typehints~=1.12.0
-    sphinx-copybutton~=0.4.0
-    sphinx-gallery~=0.10.1
-    sphinx-rtd-theme~=1.0.0
-    sphinxcontrib-katex~=0.8.6
-    sphinx~=4.3.1
+    myst-parser>=0.15.2
+    sphinx-autodoc-typehints>=1.12.0
+    sphinx-copybutton>=0.4.0
+    sphinx-gallery>=0.10.1
+    sphinx-rtd-theme>=1.0.0
+    sphinxcontrib-katex>=0.8.6
+    sphinx>=4.3.1
 
 [options.packages.find]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ install_requires =
     jaxlib>=0.1.75
     jax>=0.2.26
     lpips>=0.1.4
+    ninja>=1.10
     pillow>=8.4.0
     pytorch-lightning>=1.5.5
     pytorchvideo>=0.1.3
@@ -82,6 +83,7 @@ dev =
     jax==0.2.26
     lpips==0.1.4
     mypy==0.910
+    ninja==1.10.2
     opencv-python~=4.5.4.60
     pillow==8.4.0
     pre-commit~=2.16.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [options]
+include_package_data = True
 install_requires =
     compressai>=1.1.9
     fvcore>=0.1.5.post20211023

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,6 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [options]
-include_package_data = True
 install_requires =
     compressai>=1.1.9
     fvcore>=0.1.5.post20211023
@@ -104,9 +103,6 @@ docs =
     sphinx-rtd-theme>=1.0.0
     sphinxcontrib-katex>=0.8.6
     sphinx>=4.3.1
-
-[options.package_data]
-* = *.cc
 
 [options.packages.find]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ profile = black
 author = Facebook AI Research
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Development Status :: 3 - Alpha

--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,8 @@
 
 from setuptools import setup
 
-setup()
+setup(
+    packages=["neuralcompression"],
+    package_dir={"neuralcompression": "neuralcompression"},
+    package_data={"neuralcompression": ["ext/*.cc"]},
+)

--- a/setup.py
+++ b/setup.py
@@ -3,25 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from pathlib import Path
-
 from setuptools import setup
-from torch.utils.cpp_extension import BuildExtension, CppExtension
 
-
-setup(
-    cmdclass={"build_ext": BuildExtension},
-    ext_modules=[
-        CppExtension(
-            "neuralcompression.ext._pmf_to_quantized_cdf",
-            [
-                str(
-                    Path(__file__).resolve().parent
-                    / "neuralcompression"
-                    / "ext"
-                    / "pmf_to_quantized_cdf_py.cc"
-                )
-            ],
-        ),
-    ],
-)
+setup()

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,4 @@
 
 from setuptools import setup
 
-setup(
-    packages=["neuralcompression"],
-    package_dir={"neuralcompression": "neuralcompression"},
-    package_data={"neuralcompression": ["ext/*.cc"]},
-)
+setup()

--- a/tests/data/test_clic_2020_image.py
+++ b/tests/data/test_clic_2020_image.py
@@ -6,9 +6,9 @@
 import numpy
 import pytest
 from PIL.Image import Image
+from utils import create_random_image
 
 from neuralcompression.data import CLIC2020Image
-from utils import create_random_image
 
 
 @pytest.fixture

--- a/tests/data/test_clic_2020_video.py
+++ b/tests/data/test_clic_2020_video.py
@@ -3,8 +3,6 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import random
-
 import pytest
 import pytorchvideo.data.clip_sampling
 from utils import create_random_image

--- a/tests/data/test_clic_2020_video.py
+++ b/tests/data/test_clic_2020_video.py
@@ -7,13 +7,14 @@ import random
 
 import pytest
 import pytorchvideo.data.clip_sampling
+from utils import create_random_image
 
 from neuralcompression.data import CLIC2020Video
-from utils import create_random_image
 
 
 @pytest.fixture
 def data(tmp_path):
+    num_frames = 9
     videos = [
         "Animation_1080P-01b3",
         "Animation_1080P-05f8",
@@ -25,9 +26,7 @@ def data(tmp_path):
 
         directory.mkdir(parents=True)
 
-        frames = random.choice(range(16))
-
-        for index in range(frames):
+        for index in range(num_frames):
             path = directory.joinpath(f"{index}_y.png")
 
             create_random_image(path, (3, 224, 224))

--- a/tests/distributions/test_noisy_normal.py
+++ b/tests/distributions/test_noisy_normal.py
@@ -3,9 +3,8 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from torch.distributions import Normal
-
 from distributions.test_uniform_noise import TestUniformNoise
+from torch.distributions import Normal
 
 
 class TestNoisyNormal(TestUniformNoise):

--- a/tests/functional/test_dense_image_warp.py
+++ b/tests/functional/test_dense_image_warp.py
@@ -8,9 +8,9 @@ import pytest
 import tensorflow
 import tensorflow_addons
 import torch
+from utils import create_input
 
 from neuralcompression.functional import dense_image_warp
-from utils import create_input
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/test_lpips.py
+++ b/tests/functional/test_lpips.py
@@ -6,10 +6,10 @@
 import numpy as np
 import pytest
 import torch
+from utils import rand_im
 
 from neuralcompression.functional import lpips
 from neuralcompression.metrics import LearnedPerceptualImagePatchSimilarity
-from utils import rand_im
 
 
 @pytest.mark.parametrize(

--- a/tests/functional/test_multiscale_structural_similarity.py
+++ b/tests/functional/test_multiscale_structural_similarity.py
@@ -7,10 +7,10 @@ import numpy
 import pytest
 import tensorflow
 import torch
+from utils import rand_im
 
 from neuralcompression.functional import multiscale_structural_similarity
 from neuralcompression.metrics import MultiscaleStructuralSimilarity
-from utils import rand_im
 
 
 def tf_ms_ssim(x, y):

--- a/tests/functional/test_optical_flow_to_rgb.py
+++ b/tests/functional/test_optical_flow_to_rgb.py
@@ -8,10 +8,10 @@ import pytest
 import tensorflow as tf
 import tensorflow_addons as tfa
 import torch
+from utils import create_input
 
 import neuralcompression.functional as ncF
 from neuralcompression.functional import optical_flow_to_color
-from utils import create_input
 
 
 @pytest.mark.parametrize(

--- a/tests/layers/test_continuous_entropy.py
+++ b/tests/layers/test_continuous_entropy.py
@@ -8,8 +8,8 @@ import torch
 import torch.testing
 from torch import Size
 
-from neuralcompression.layers import ContinuousEntropy
 from neuralcompression.distributions import NoisyNormal
+from neuralcompression.layers import ContinuousEntropy
 
 
 class TestContinuousEntropy:

--- a/tests/models/test_prior_autoencoder.py
+++ b/tests/models/test_prior_autoencoder.py
@@ -6,11 +6,7 @@
 from compressai.entropy_models import EntropyBottleneck
 from torch import Tensor
 
-from neuralcompression.layers import (
-    AnalysisTransformation2D,
-    SynthesisTransformation2D,
-)
-
+from neuralcompression.layers import AnalysisTransformation2D, SynthesisTransformation2D
 from neuralcompression.models import PriorAutoencoder
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,9 +3,9 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import PIL
 import numpy
 import numpy as np
+import PIL
 import torch
 
 


### PR DESCRIPTION
This is a potpourri of fixes.

**Dependencies**
Currently, we require very specific package versions for **any** install. This is too restrictive for a research package where researchers may have a variety of reasons to carefully tailor their environment. This PR resolves the issue by allowing general installation to have flexible packages. To maintain CI stability and functionality, the fixed version requirements have been moved to `dev`.

**Build**
We build our CPP extension using `load` instead of `setup.py`. This removes PyTorch as a dependency at install time and removes the need for us to distribute binaries. This required adding `ninja` as a dependency. Hopefully we can get rid of it eventually, but this temporarily should fix distribution.

**CI testing**
`isort` was misconfigured and missed a lot of import changes. I fixed the config and ran it on all files to update import sorting.

**Other**
While implementing this I also found a few other minor issues with respect to versioning, tests, and formatting that I resolved.

This PR makes NeuralCompression require Python 3.8 due to its usage of `importlib`.

**Testing**
Testing done via CI.
