### PR TITLE
Remove `torch` from `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,9 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-    "setuptools-scm~=6.3.2",
-    "setuptools~=59.5.0",
-    "torch~=1.10.0",
-    "wheel~=0.37.0",
+    "setuptools-scm>=6.3.2",
+    "setuptools>=59.5.0",
+    "wheel>=0.37.0",
 ]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
`torch` is no longer necessary to run `setup.py`, so let's remove it as a build requirement.

Other package versions are made flexible so we use the latest Python packaging infra for distribution. I couldn't think of any clear downsides to this, but we could keep the old behavior if desired.