### PR TITLE
Fix required Python version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,7 +70,7 @@ install_requires =
     torchvision>=0.11.1
     tqdm>=4.62.3
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
Bug found by @QuentinDuval. I updated the Python metadata to list Python 3.8, but forgot the `python_requires = >=3.8` line.
