### PR TITLE
Rename fields under `extra_requires` in `setup.cfg`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade wheel
-          pip install --editable ".[dev, docs]"
+          pip install --editable ".[tests]"
       - name: Check Formatting and Lint
         run: |
           python --version

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ First, clone the repository and navigate to the NeuralCompression root
 directory and install the package in development mode by running:
 
 ```bash
-pip install --editable ".[dev, docs]"
+pip install --editable ".[tests]"
 ```
 
-If you are not interested in matching the test environment, then you only need
-to apply the second step to install.
+If you are not interested in matching the test environment, then you can just
+apply `pip install -e .`.
 
 ## Repository Structure
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,28 +74,14 @@ python_requires = >=3.8
 
 [options.extras_require]
 dev =
-    black==21.12b0
-    compressai==1.1.9
-    flake8==4.0.1
-    fvcore==0.1.5.post20211023
-    h5py==3.1.0
-    isort==5.10.1
-    jaxlib==0.1.75
-    jax==0.2.26
-    lpips==0.1.4
-    mypy==0.910
-    ninja==1.10.2
-    opencv-python~=4.5.4.60
-    pillow==8.4.0
-    pre-commit~=2.16.0
-    pytest==6.2.5
-    pytorch-lightning==1.5.5
-    pytorchvideo==0.1.3
-    tensorflow-addons~=0.15.0
-    tensorflow~=2.7.0
-    torch==1.10.1
-    torchmetrics==0.6.1
-    torchvision==0.11.2
+    black>=21.12b0
+    flake8>=4.0.1
+    isort>=5.10.1
+    mypy>=0.910
+    pre-commit>=2.16.0
+    pytest>=6.2.5
+    tensorflow-addons>=0.15.0
+    tensorflow>=2.7.0
 docs =
     myst-parser>=0.15.2
     sphinx-autodoc-typehints>=1.12.0
@@ -104,6 +90,28 @@ docs =
     sphinx-rtd-theme>=1.0.0
     sphinxcontrib-katex>=0.8.6
     sphinx>=4.3.1
+tests =
+    black==21.12b0
+    compressai==1.1.9
+    flake8==4.0.1
+    fvcore==0.1.5.post20211023
+    h5py-=3.6.0
+    isort==5.10.1
+    jaxlib==0.1.75
+    jax==0.2.26
+    lpips==0.1.4
+    mypy==0.931
+    ninja==1.10.2.3
+    opencv-python~=4.5.5.62
+    pillow==9.0.0
+    pre-commit==2.16.0
+    pytest==6.2.5
+    pytorchvideo==0.1.3
+    tensorflow-addons==0.15.0
+    tensorflow==2.7.0
+    torch==1.10.1
+    torchmetrics==0.6.2
+    torchvision==0.11.2
 
 [options.packages.find]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -95,7 +95,7 @@ tests =
     compressai==1.1.9
     flake8==4.0.1
     fvcore==0.1.5.post20211023
-    h5py-=3.6.0
+    h5py==3.6.0
     isort==5.10.1
     jaxlib==0.1.75
     jax==0.2.26


### PR DESCRIPTION
Rename fields in `extra_requires` to specify that strict versions are required for the test environment and not a development environment.

I think some users will want to have flexible packages for development. If they want to see if their code will pass CI they can always install the test environment directly.

This required some reconfiguration of CI to use the test environment rather than `dev`.

With this PR, hopefully the only part of the repo we need to watch versions carefully will be `tests` under `extra_requires`.
