### PR TITLE
Remove pytorch-lightning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,6 @@ install_requires =
     lpips>=0.1.4
     ninja>=1.10
     pillow>=8.4.0
-    pytorch-lightning>=1.5.5
     pytorchvideo>=0.1.3
     torch>=1.10.0
     torchmetrics>=0.6.1


### PR DESCRIPTION
We don't have any PyTorch Lightning code in the core `neuralcompression` package, so we don't need it as a requirement.
