### PR TITLE
Pin click

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -91,6 +91,7 @@ docs =
     sphinx>=4.3.1
 tests =
     black==21.12b0
+    click==8.0.4
     compressai==1.1.9
     flake8==4.0.1
     fvcore==0.1.5.post20211023


### PR DESCRIPTION
Pin the version of click so that `black` stops throwing errors due to unavailable import.
