### PR TITLE
Ensure sorted CLIC

### DIFF
--- a/neuralcompression/data/_clic_2020_image.py
+++ b/neuralcompression/data/_clic_2020_image.py
@@ -90,7 +90,7 @@ class CLIC2020Image(Dataset):
         if download:
             self.download()
 
-        self.paths = [*self.root.joinpath(self.split).glob("*.png")]
+        self.paths = sorted([*self.root.joinpath(self.split).glob("*.png")])
 
     def __getitem__(self, index: int) -> Image:
         path = self.paths[index]


### PR DESCRIPTION
This PR updates the CLIC dataloader to sort all image paths. Not sure how exactly it ordered the paths before this change, but I found that it was different depending on context/system.