### PR TITLE
pad image at inference time, remove resize

### DIFF
--- a/tests/test_scale_hyperprior.py
+++ b/tests/test_scale_hyperprior.py
@@ -26,6 +26,7 @@ def test_hyperprior_forward(network_channels, compression_channels, img_size):
     model = ScaleHyperprior(
         network_channels=network_channels, compression_channels=compression_channels
     )
+    model.eval()
     outputs = model(inp)
     assert outputs[0].shape == inp.shape
 


### PR DESCRIPTION
## Changes

At inference time, pad the image instead of doing an interpolation-based resize, which gives poor results (e.g. on PSNR) when the input image heigh and/or width is not exactly divisible by the downsampling factor (`=2^{number of downsampling layers}`).

