### PR TITLE
Open Images + DIV2K dataset + testing updates

### DIFF
--- a/neuralcompression/data/__init__.py
+++ b/neuralcompression/data/__init__.py
@@ -5,5 +5,7 @@
 
 from ._clic_2020_image import CLIC2020Image
 from ._clic_2020_video import CLIC2020Video
+from ._div2k_dataset import DIV2KDataset
 from ._kodak import Kodak
+from ._openimages_v6 import OpenImagesV6
 from ._vimeo_90k_septuplet import Vimeo90kSeptuplet

--- a/neuralcompression/data/_div2k_dataset.py
+++ b/neuralcompression/data/_div2k_dataset.py
@@ -1,0 +1,63 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from pathlib import Path
+from typing import Callable, Optional, Union
+
+import torchvision.datasets.folder
+import torchvision.datasets.utils
+from PIL.Image import Image
+from torch import Tensor
+from torch.utils.data import Dataset
+
+
+class DIV2KDataset(Dataset):
+    """
+    Dataloader for DIV2K Dataset.
+
+    The DIV2K dataset was released for the 2017 NTIRE challenge on single-image
+    super resolution. The dataset is documented in the following paper:
+
+    NTIRE 2017 challenge on single image super-resolution: Dataset and study
+    E Agustsson, R Timofte
+
+    Args:
+        root: Root directory of dataset.
+        split: Split of the dataset (currently only 'val' is accepted).
+        transform: Torchvision PIL transform for converting the images.
+    """
+
+    split_map = {
+        "val": "DIV2K_valid_HR",
+    }
+
+    def __init__(
+        self,
+        root: Union[str, Path],
+        split: str = "val",
+        transform: Optional[Callable[[Image], Tensor]] = None,
+    ):
+        self.root: Path = Path(root)
+
+        if split not in ("val",):
+            raise ValueError("Invalid split.")
+
+        self.split = self.split_map[split]
+        self.transform = transform
+
+        self.paths = sorted([*self.root.joinpath(self.split).glob("*.png")])
+
+    def __getitem__(self, index: int) -> Image:
+        path = self.paths[index]
+
+        image = torchvision.datasets.folder.default_loader(path)
+
+        if self.transform is not None:
+            image = self.transform(image)
+
+        return image
+
+    def __len__(self) -> int:
+        return len(self.paths)

--- a/neuralcompression/data/_openimages_v6.py
+++ b/neuralcompression/data/_openimages_v6.py
@@ -1,0 +1,83 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+from pathlib import Path
+from typing import Callable, List, Optional, Union
+
+from torch.utils.data import Dataset
+from torchvision.datasets.folder import default_loader
+
+
+def _load_indices(indices_path: Path) -> List[str]:
+    with open(indices_path, "r") as f:
+        indices = sorted(f.readlines())
+    image_names = [os.path.splitext(el.rstrip())[0] for el in indices]
+
+    return image_names
+
+
+class OpenImagesV6(Dataset):
+    """
+    Open Images V6 data loader
+
+    This is a minimalist dataloader for Open Images V6. Since Open Images puts
+    all data into a single folder, it is expected that the user has already
+    created a text file with all the images of the split prior to instantiating
+    this class (otherwise an ``os.walk`` takes forever). The train file should
+    be called 'list_train_files.txt' by default, for example.
+
+    If the user gives a different name to the image list file, the new filename
+    can be specified in the ``__init__`` function.
+
+    Args:
+        root: Root direcotry for Open Images V6.
+        split: Which split of the dataset (one of 'train', 'val', or 'test').
+            This is used to indicate the subfolder of ``root`` where the images
+            are stored, except for the case of 'val', which is renamed to
+            'validation'
+        image_list_file: The file containing all image names under the split.
+            By default, it assumes the file has the name
+            'list-{split}-files.txt'.
+        transform: A torchvision PIL transform.
+    """
+
+    split_map = {"train": "train", "val": "validation", "test": "test"}
+
+    def __init__(
+        self,
+        root: Union[str, Path],
+        split: str,
+        image_list_file: Optional[Union[str, Path]] = None,
+        transform: Optional[Callable] = None,
+    ) -> None:
+        super().__init__()
+        if split not in ("train", "val", "test"):
+            raise ValueError("Split must be in ('train', 'val', 'test')")
+
+        self.root = Path(root)
+        self.split = self.split_map[split]
+        self.transform = transform
+
+        if image_list_file is None:
+            self.image_list_file = self.root / f"list-{self.split}-files.txt"
+
+        self.indices = _load_indices(self.image_list_file)
+
+    def _get_image_path(self, index: int) -> Path:
+        fname = self.indices[index]
+        return self.root / self.split / (fname + ".jpg")
+
+    def __getitem__(self, index: int):
+        image_full_path = self._get_image_path(index)
+        image = default_loader(image_full_path)
+
+        if self.transform is not None:
+            image = self.transform(image)
+
+        return image
+
+    def __len__(self) -> int:
+        return len(self.indices)

--- a/neuralcompression/data/_openimages_v6.py
+++ b/neuralcompression/data/_openimages_v6.py
@@ -63,6 +63,8 @@ class OpenImagesV6(Dataset):
 
         if image_list_file is None:
             self.image_list_file = self.root / f"list-{self.split}-files.txt"
+        else:
+            self.image_list_file = Path(image_list_file)
 
         self.indices = _load_indices(self.image_list_file)
 

--- a/tests/data/test_clic_2020_image.py
+++ b/tests/data/test_clic_2020_image.py
@@ -6,7 +6,7 @@
 import numpy
 import pytest
 from PIL.Image import Image
-from utils import create_random_image
+from utils import create_random_image, write_image_to_file
 
 from neuralcompression.data import CLIC2020Image
 
@@ -24,7 +24,8 @@ def data(tmp_path):
     for index in range(n):
         path = directory.joinpath(f"{index}.png")
 
-        create_random_image(path, (3, 224, 224))
+        img = create_random_image((3, 224, 224), rng)
+        write_image_to_file(img, path)
 
     return CLIC2020Image(tmp_path, split="test"), n
 
@@ -34,6 +35,7 @@ class TestCLIC2020Image:
         data, _ = data
 
         assert isinstance(data[0], Image)
+        assert isinstance(data[-1], Image)
 
     def test___len__(self, data):
         data, n = data

--- a/tests/data/test_clic_2020_video.py
+++ b/tests/data/test_clic_2020_video.py
@@ -5,7 +5,7 @@
 
 import pytest
 import pytorchvideo.data.clip_sampling
-from utils import create_random_image
+from utils import create_random_image, write_image_to_file
 
 from neuralcompression.data import CLIC2020Video
 
@@ -27,7 +27,8 @@ def data(tmp_path):
         for index in range(num_frames):
             path = directory.joinpath(f"{index}_y.png")
 
-            create_random_image(path, (3, 224, 224))
+            img = create_random_image((3, 224, 224))
+            write_image_to_file(img, path)
 
     clip_sampler = pytorchvideo.data.clip_sampling.make_clip_sampler("random", 4)
 
@@ -44,6 +45,7 @@ class TestCLIC2020Video:
         data, _ = data
 
         assert isinstance(data[0], dict)
+        assert isinstance(data[-1], dict)
 
     def test___len__(self, data):
         data, n = data

--- a/tests/data/test_div2k.py
+++ b/tests/data/test_div2k.py
@@ -8,11 +8,10 @@ from pathlib import Path
 import numpy
 import pytest
 import torch
-from PIL.Image import Image
+from torchvision.transforms import ToTensor
 from utils import create_random_image, write_image_to_file
 
 from neuralcompression.data import DIV2KDataset
-from torchvision.transforms import ToTensor
 
 
 @pytest.fixture
@@ -43,3 +42,5 @@ def test_div2k_getitem(div2k_datafolder):
     true_images = div2k_datafolder[1]
     for img, true_img in zip(dataset, true_images):
         assert torch.allclose(img, torch.tensor(true_img))
+
+    assert len(dataset) == len(true_images)

--- a/tests/data/test_div2k.py
+++ b/tests/data/test_div2k.py
@@ -1,0 +1,45 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from pathlib import Path
+
+import numpy
+import pytest
+import torch
+from PIL.Image import Image
+from utils import create_random_image, write_image_to_file
+
+from neuralcompression.data import DIV2KDataset
+from torchvision.transforms import ToTensor
+
+
+@pytest.fixture
+def div2k_datafolder(tmp_path: Path):
+    rng = numpy.random.default_rng(0xFEEEFEEE)
+
+    directory = tmp_path.joinpath("div2k").joinpath("DIV2K_valid_HR")
+
+    directory.mkdir(parents=True)
+
+    n = int(rng.integers(1, 16, (1,)))
+
+    images = []
+
+    for index in range(n):
+        path = directory.joinpath(f"{index:03}.png")
+
+        images.append(create_random_image((3, 224, 224), rng))
+        write_image_to_file(images[-1], path)
+
+    return directory.parent, images
+
+
+def test_div2k_getitem(div2k_datafolder):
+    transform = ToTensor()
+    dataset = DIV2KDataset(div2k_datafolder[0], transform=transform)
+
+    true_images = div2k_datafolder[1]
+    for img, true_img in zip(dataset, true_images):
+        assert torch.allclose(img, torch.tensor(true_img))

--- a/tests/data/test_open_images.py
+++ b/tests/data/test_open_images.py
@@ -28,6 +28,7 @@ def open_images_datafolder(tmp_path: Path):
 
         images = []
 
+        # NOTE: update this if we switch to arbitrary split paths
         with open(base_dir / f"list-{subfolder}-files.txt", "w") as f:
             for index in range(n):
                 path = directory.joinpath(f"{index:03}.jpg")

--- a/tests/data/test_open_images.py
+++ b/tests/data/test_open_images.py
@@ -1,0 +1,60 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from pathlib import Path
+
+import numpy
+import pytest
+import torch
+from torchvision.transforms import ToTensor
+from utils import create_deterministic_image, write_image_to_file
+
+from neuralcompression.data import OpenImagesV6
+
+
+@pytest.fixture
+def open_images_datafolder(tmp_path: Path):
+    rng = numpy.random.default_rng(0xFEEEFEEE)
+
+    root = tmp_path / "open_images"
+
+    def write_folder_and_flist(base_dir: Path, subfolder: str):
+        directory = base_dir / subfolder
+        directory.mkdir(parents=True)
+
+        n = int(rng.integers(1, 16, (1,)))
+
+        images = []
+
+        with open(base_dir / f"list-{subfolder}-files.txt", "w") as f:
+            for index in range(n):
+                path = directory.joinpath(f"{index:03}.jpg")
+
+                images.append(create_deterministic_image((3, 224, 224), index))
+                write_image_to_file(images[-1], path)
+                f.write(f"{path.name}\n")
+
+            return images
+
+    train_images = write_folder_and_flist(root, "train")
+    val_images = write_folder_and_flist(root, "validation")
+    test_images = write_folder_and_flist(root, "test")
+
+    return root, [train_images, val_images, test_images]
+
+
+def test_div2k_getitem(open_images_datafolder):
+    transform = ToTensor()
+
+    for split, true_images in zip(["train", "val", "test"], open_images_datafolder[1]):
+        dataset = OpenImagesV6(
+            open_images_datafolder[0], split=split, transform=transform
+        )
+
+        for img, true_img in zip(dataset, true_images):
+            # because these are saved with JPEG, we need a really high tol
+            assert torch.allclose(img, torch.tensor(true_img), rtol=0.01, atol=0.01)
+
+        assert len(dataset) == len(true_images)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,19 +3,26 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+from pathlib import Path
 from typing import Optional
 
-from pathlib import Path
 import numpy as np
-from PIL import Image
 import torch
 from numpy.random import Generator
+from PIL import Image
 
 
-def create_input(shape):
-    x = np.arange(np.product(shape)).reshape(shape)
+def create_input(shape, offset: int = 0):
+    x = np.arange(np.product(shape)).reshape(shape) + offset
 
     return torch.from_numpy(x).to(torch.get_default_dtype())
+
+
+def create_deterministic_image(shape, offset: int = 0):
+    img = create_input(shape, offset).numpy()
+    img = ((255.0 / img.max()) * img).astype(np.uint8)
+    res = img.astype(np.float32) / 255
+    return res
 
 
 def create_random_image(shape, rng: Optional[Generator] = None):
@@ -31,7 +38,10 @@ def write_image_to_file(img: np.ndarray, file_path: Path):
     img = (img * 255.0).astype(np.uint8)
     img = np.transpose(img, (1, 2, 0))
     pil_img = Image.fromarray(img)
-    pil_img.save(file_path)
+    if ".jpg" in file_path.name or ".jpeg" in file_path.name:
+        pil_img.save(file_path, quality=100, subsampling=0)
+    else:
+        pil_img.save(file_path)
 
 
 def rand_im(shape, rng=None):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,10 +3,13 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-import numpy
+from typing import Optional
+
+from pathlib import Path
 import numpy as np
-import PIL
+from PIL import Image
 import torch
+from numpy.random import Generator
 
 
 def create_input(shape):
@@ -15,17 +18,23 @@ def create_input(shape):
     return torch.from_numpy(x).to(torch.get_default_dtype())
 
 
-def create_random_image(file_path, shape):
-    img = numpy.random.random_sample(shape)
-    img = (255.0 / img.max() * (img - img.min())).astype(numpy.uint8)
-    res = torch.tensor(img).to(torch.float) / 255
-    img = numpy.transpose(img, (1, 2, 0))
-    img = PIL.Image.fromarray(img)
-    img.save(file_path)
+def create_random_image(shape, rng: Optional[Generator] = None):
+    if rng is None:
+        rng = np.random.default_rng()
+    img = rng.random(shape)
+    img = (255.0 / img.max() * (img - img.min())).astype(np.uint8)
+    res = img.astype(np.float32) / 255
     return res
+
+
+def write_image_to_file(img: np.ndarray, file_path: Path):
+    img = (img * 255.0).astype(np.uint8)
+    img = np.transpose(img, (1, 2, 0))
+    pil_img = Image.fromarray(img)
+    pil_img.save(file_path)
 
 
 def rand_im(shape, rng=None):
     if rng is None:
-        rng = numpy.random.default_rng()
+        rng = np.random.default_rng()
     return torch.tensor(rng.uniform(size=shape), dtype=torch.get_default_dtype())


### PR DESCRIPTION
This PR introduces the DIV2K and Open Images datasets. It also introduces a few testing updates for `utils.py`, in particular splitting apart the logic for creating a random image vs. writing it to a temporary file.