### PR TITLE
Add loss functions

### DIFF
--- a/neuralcompression/loss_fn/__init__.py
+++ b/neuralcompression/loss_fn/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from ._binary_crossentropy_loss import (
+    BinaryCrossentropyDiscriminatorLoss,
+    BinaryCrossentropyGeneratorLoss,
+)
+from ._distortion_loss import DistortionLoss
+from ._gan_losses import DiscriminatorLoss, GeneratorLoss
+from ._mse_loss import MSELoss
+from ._mse_lpips_loss import MSELPIPSLoss
+from ._normfix_lpips import NormFixLPIPS
+from ._oasis_loss import OASISDiscriminatorLoss, OASISGeneratorLoss
+from ._target_rate_config import TargetRateConfig

--- a/neuralcompression/loss_fn/_binary_crossentropy_loss.py
+++ b/neuralcompression/loss_fn/_binary_crossentropy_loss.py
@@ -1,0 +1,70 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from ._gan_losses import DiscriminatorLoss, GeneratorLoss
+
+
+class BinaryCrossentropyDiscriminatorLoss(DiscriminatorLoss):
+    """
+    Binary cross-entropy discriminator loss function.
+
+    This callable applies the standard non-saturating binary cross-entropy
+    loss for training GANs.
+
+    Args:
+        real_logits: Logits of the real input.
+        fake_logits: Logits of the fake input.
+        target: The target for crossentropy. Typically, this will be a ones
+            tensor of the same size as ``real_logits``.
+
+    Returns:
+        The binary cross-entropy discriminator loss.
+    """
+
+    def __call__(
+        self, real_logits: Tensor, fake_logits: Tensor, target: Tensor
+    ) -> Tensor:
+        if target.ndim == 0:
+            target = target * torch.ones_like(real_logits)
+        elif target.ndim != real_logits.ndim:
+            raise ValueError("Misconfigured GAN loss starget dimension.")
+
+        return 0.5 * (
+            F.binary_cross_entropy_with_logits(real_logits, target)
+            + F.binary_cross_entropy_with_logits(
+                fake_logits,
+                torch.zeros_like(target),
+            )
+        )
+
+
+class BinaryCrossentropyGeneratorLoss(GeneratorLoss):
+    """
+    Binary cross-entropy generator loss function.
+
+    This callable applies the standard non-saturating binary cross-entropy
+    loss for training GANs. It is a sign flip of the discriminator loss term
+    and includes no 'fake' logit calculation.
+
+    Args:
+        logits: Logits of the input.
+        target: The target for crossentropy. Typically, this will be a ones
+            tensor of the same size as ``logits``.
+
+    Returns:
+        The binary cross-entropy generator loss.
+    """
+
+    def __call__(self, logits: Tensor, target: Tensor) -> Tensor:
+        if target.ndim == 0:
+            target = target * torch.ones_like(logits)
+        elif target.ndim != logits.ndim:
+            raise ValueError("Misconfigured GAN loss starget dimension.")
+
+        return F.binary_cross_entropy_with_logits(logits, target)

--- a/neuralcompression/loss_fn/_distortion_loss.py
+++ b/neuralcompression/loss_fn/_distortion_loss.py
@@ -1,0 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch.nn as nn
+from torch import Tensor
+
+
+class DistortionLoss(nn.Module):
+    """
+    Abstract base class for distortion loss functions.
+    """
+
+    def __call__(self, image: Tensor, reference: Tensor) -> Tensor:
+        raise NotImplementedError

--- a/neuralcompression/loss_fn/_gan_losses.py
+++ b/neuralcompression/loss_fn/_gan_losses.py
@@ -1,0 +1,27 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch.nn as nn
+from torch import Tensor
+
+
+class DiscriminatorLoss(nn.Module):
+    """
+    Abstract base class for discriminator loss functions.
+    """
+
+    def __call__(
+        self, real_logits: Tensor, fake_logits: Tensor, target: Tensor
+    ) -> Tensor:
+        raise NotImplementedError
+
+
+class GeneratorLoss(nn.Module):
+    """
+    Abstract base class for generator loss functions.
+    """
+
+    def __call__(self, logits: Tensor, target: Tensor) -> Tensor:
+        raise NotImplementedError

--- a/neuralcompression/loss_fn/_mse_loss.py
+++ b/neuralcompression/loss_fn/_mse_loss.py
@@ -1,0 +1,39 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch.nn.functional as F
+from torch import Tensor
+
+from ._distortion_loss import DistortionLoss
+
+
+class MSELoss(DistortionLoss):
+    """
+    Mean-squared error loss function.
+
+    This function assumes the input images are in the [0.0, 1.0] range. To
+    match existing neural compression implementations, the MSE result is
+    multiplied by ``scale_param``, which is 255.0**2 by default.
+
+    Args:
+        scale_param: The scaling parameter for the loss term.
+    """
+
+    def __init__(self, scale_param: float = 255.0**2):
+        super().__init__()
+        self.scale_param = scale_param
+
+    def __call__(self, image: Tensor, reference: Tensor) -> Tensor:
+        """
+        Apply the MSE loss.
+
+        Args:
+            image: The image to measure MSE loss from.
+            reference: The reference or 'ground truth' image.
+
+        Returns:
+            The MSE loss value.
+        """
+        return self.scale_param * F.mse_loss(image, reference)

--- a/neuralcompression/loss_fn/_mse_lpips_loss.py
+++ b/neuralcompression/loss_fn/_mse_lpips_loss.py
@@ -1,0 +1,61 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch.nn.functional as F
+from torch import Tensor
+
+from ._distortion_loss import DistortionLoss
+from ._normfix_lpips import NormFixLPIPS
+
+
+class MSELPIPSLoss(DistortionLoss):
+    """
+    MSE-LPIPS distortion loss.
+
+    This class combines both mean-squared error and LPIPS into a single loss
+    function. The final loss is calculated as
+
+    ``mse_param * mse + lpips_param * lpips``
+
+    Args:
+        mse_param: A parameter for scaling the MSE term.
+        lpips_param: A parameter for scaling the LPIPS term.
+        normalize: Whether to normalize inputs to the [-1.0, 1.0] range prior
+            to LPIPS calculation.
+        backbone: String specifying which classifier model to use as the
+            backbone for LPIPS calculation.
+    """
+
+    def __init__(
+        self,
+        mse_param: float = 255.0**2,
+        lpips_param: float = 1.0,
+        normalize: bool = True,
+        backbone: str = "vgg",
+    ):
+        super().__init__()
+        self.mse_param = mse_param
+        self.lpips_param = lpips_param
+        self.normalize = normalize
+        self.lpips_model = NormFixLPIPS(net=backbone).eval()
+        for param in self.lpips_model.parameters():
+            param.requires_grad_(False)
+
+    def __call__(self, image: Tensor, reference: Tensor) -> Tensor:
+        """
+        Calculate the MSE-LPIPS loss.
+
+        Args:
+            image: The test image to calculate its distortion.
+            reference: The 'ground truth' image.
+
+        Returns:
+            The MSE-LPIPS loss value.
+        """
+        return (
+            self.mse_param * F.mse_loss(image, reference)
+            + self.lpips_param
+            * self.lpips_model(image, reference, normalize=self.normalize).mean()
+        )

--- a/neuralcompression/loss_fn/_normfix_lpips.py
+++ b/neuralcompression/loss_fn/_normfix_lpips.py
@@ -1,0 +1,87 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from lpips import LPIPS
+from lpips.lpips import spatial_average, upsample
+
+
+def normalize_tensor(x, eps=1e-8):
+    norm_factor = torch.sqrt(torch.sum(x**2 + eps, dim=1, keepdim=True))
+    return x / (norm_factor)
+
+
+class NormFixLPIPS(LPIPS):
+    """
+    LPIPS loss function for propagating gradients.
+
+    The online implementation of LPIPS includes a square root normalization
+    term that is often 0 during training. For the metric version of LPIPS, this
+    is not an issue since the metric includes divide-by-0 protection. However,
+    when using LPIPS as a loss function, the 0 can lead to infinite gradients.
+
+    This class addresses this by putting the 0 protection inside the square
+    root term, making gradient propagation stable.
+
+    See parent class ``LPIPS`` for arguments.
+    """
+
+    def train(self, mode: bool = True) -> "NormFixLPIPS":
+        """the lpips network should be in eval mode."""
+        return super().train(False)
+
+    def forward(self, in0, in1, retPerLayer=False, normalize=False):
+        if (
+            normalize
+        ):  # turn on this flag if input is [0,1] so it can be adjusted to [-1, +1]
+            in0 = 2 * in0 - 1
+            in1 = 2 * in1 - 1
+
+        # v0.0 - original release had a bug, where input was not scaled
+        in0_input, in1_input = (
+            (self.scaling_layer(in0), self.scaling_layer(in1))
+            if self.version == "0.1"
+            else (in0, in1)
+        )
+        outs0, outs1 = self.net.forward(in0_input), self.net.forward(in1_input)
+        feats0, feats1, diffs = {}, {}, {}
+
+        for kk in range(self.L):
+            feats0[kk], feats1[kk] = normalize_tensor(outs0[kk]), normalize_tensor(
+                outs1[kk]
+            )
+            diffs[kk] = (feats0[kk] - feats1[kk]) ** 2
+
+        if self.lpips:
+            if self.spatial:
+                res = [
+                    upsample(self.lins[kk](diffs[kk]), out_HW=in0.shape[2:])
+                    for kk in range(self.L)
+                ]
+            else:
+                res = [
+                    spatial_average(self.lins[kk](diffs[kk]), keepdim=True)
+                    for kk in range(self.L)
+                ]
+        else:
+            if self.spatial:
+                res = [
+                    upsample(diffs[kk].sum(dim=1, keepdim=True), out_HW=in0.shape[2:])
+                    for kk in range(self.L)
+                ]
+            else:
+                res = [
+                    spatial_average(diffs[kk].sum(dim=1, keepdim=True), keepdim=True)
+                    for kk in range(self.L)
+                ]
+
+        val = 0
+        for lind in range(self.L):
+            val += res[lind]
+
+        if retPerLayer:
+            return (val, res)
+        else:
+            return val

--- a/neuralcompression/loss_fn/_oasis_loss.py
+++ b/neuralcompression/loss_fn/_oasis_loss.py
@@ -1,0 +1,111 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from ._gan_losses import DiscriminatorLoss, GeneratorLoss
+
+
+def _verify_logit_target_shape(logits: Tensor, target: Tensor):
+    if logits.ndim != 4:
+        raise ValueError("Only expect 4-dimensional logits.")
+    if target.ndim != 3:
+        raise ValueError("Only expect 3-dimensional targets.")
+
+    expected_target_numel = logits.shape[0] * logits.shape[-2] * logits.shape[-1]
+    actual_target_shape = target.numel()
+    logits_shape = logits.shape
+    if expected_target_numel != actual_target_shape:
+        raise ValueError(
+            f"Based on logits size {logits_shape}, expected target numel to be "
+            f"{expected_target_numel}, but found {actual_target_shape}"
+        )
+
+
+class OASISDiscriminatorLoss(DiscriminatorLoss):
+    """
+    Discriminator loss function from OASIS paper.
+
+    This applies a spatially-distributed non-saturating GAN discriminator loss.
+    Effectively, it takes a spatially-varying target map and calculates the
+    crossentropy over the targets.
+
+    This loss was introduced in the following paper:
+
+    You Only Need Adversarial Supervision for Semantic Image Synthesis
+    Vadim Sushko, Edgar Schönfeld, Dan Zhang, Juergen Gall, Bernt Schiele,
+    Anna Khoreva
+    """
+
+    def __call__(
+        self, real_logits: Tensor, fake_logits: Tensor, target: Tensor
+    ) -> Tensor:
+        """
+        Calculate OASIS discriminator loss.
+
+        Args:
+            real_logits: The 4-D map of logits for the real variables. The
+                dimensions are expected to be ``(batch, num_classes+1, ny, nx).
+            fake_logits: the 4-D map of logits for the fake variables, with the
+                same dimensions as the ``real_logits`.
+            target: A 3-D map of spatially-varying ground truth labels.
+
+        Returns:
+            The OASIS discriminator loss value.
+        """
+        _verify_logit_target_shape(real_logits, target)
+        _verify_logit_target_shape(fake_logits, target)
+        if target.dtype != torch.long:
+            raise ValueError("Expected target to have dtype torch.long.")
+
+        batch_size, num_classes, _, _ = real_logits.shape
+
+        target = target.view(batch_size, -1)
+        return 0.5 * (
+            F.cross_entropy(real_logits.view(batch_size, num_classes, -1), target + 1)
+            + F.cross_entropy(
+                fake_logits.view(batch_size, num_classes, -1),
+                torch.zeros_like(target),
+            )
+        )
+
+
+class OASISGeneratorLoss(GeneratorLoss):
+    """
+    Generator loss function from OASIS paper.
+
+    This applies a spatially-distributed non-saturating GAN generator loss.
+    Effectively, it takes a spatially-varying target map and calculates the
+    crossentropy over the targets.
+
+    This loss was introduced in the following paper:
+
+    You Only Need Adversarial Supervision for Semantic Image Synthesis
+    Vadim Sushko, Edgar Schönfeld, Dan Zhang, Juergen Gall, Bernt Schiele,
+    Anna Khoreva
+    """
+
+    def __call__(self, logits: Tensor, target: Tensor) -> Tensor:
+        """
+        Calculate OASIS discriminator loss.
+
+        Args:
+            logits: The 4-D map of logits for the variables. The dimensions are
+                expected to be ``(batch, num_classes+1, ny, nx).
+            target: A 3-D map of spatially-varying ground truth labels.
+
+        Returns:
+            The OASIS generator loss value.
+        """
+        _verify_logit_target_shape(logits, target)
+        if target.dtype != torch.long:
+            raise ValueError("Expected target to have dtype torch.long.")
+
+        batch_size, num_classes, _, _ = logits.shape
+
+        target = target.view(batch_size, -1)
+        return F.cross_entropy(logits.view(batch_size, num_classes, -1), target + 1)

--- a/neuralcompression/loss_fn/_target_rate_config.py
+++ b/neuralcompression/loss_fn/_target_rate_config.py
@@ -1,0 +1,85 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import List, Tuple
+
+
+class TargetRateConfig:
+    """
+    HifiC-style target rate config.
+
+    This class wraps all variables used for rate targeting as used in the HiFiC
+    paper. When the calculated rate is higher than the target, a higher coding
+    cost is applied. Vice versa when the calculated rate is lower.
+
+    This class alone does not apply the rate targeting - it is simply a
+    convenience data wrapper to help the user.
+
+    See the HiFiC paper for further details:
+
+    High-Fidelity Generative Image Compression
+    Fabian Mentzer, George D. Toderici, Michael Tschannen, Eirikur Agustsson
+
+    Args:
+        target_bpp: The target bits-per-pixel rate.
+        target_factors: The scaling values for different levels of training.
+            For example, a value of [1.4, 1.0] would shift the target rate
+            40% higher at the beginning of training before lowering it to
+            ``target_bpp``.
+        target_steps: Training steps to adjust ``target_bpp`` based on
+            ``target_factors``.
+        lam_levels: Lambda levels for adjusting coding cost, with the first
+            being smaller than the second.
+        lam2_factors: Same as ``target_factors`` - adjust the second lambda
+            values based on training stage.
+        lam2_steps: Same as ``target_steps`` - adjust the second lambda values
+            at these step intervals.
+    """
+
+    def __init__(
+        self,
+        target_bpp: float,
+        target_factors: List[float],
+        target_steps: List[int],
+        lam_levels: Tuple[float, float],
+        lam2_factors: List[float],
+        lam2_steps: List[int],
+    ):
+        if len(target_steps) + 1 != len(target_factors) or len(lam2_steps) + 1 != len(
+            lam2_factors
+        ):
+            raise ValueError(
+                "Expect length of steps list to be 1 less than factors list."
+            )
+        self._target_bpp = target_bpp
+        self._target_factors = target_factors
+        self._target_steps = target_steps
+        self._lam_levels = lam_levels
+        self._lam2_factors = lam2_factors
+        self._lam2_steps = lam2_steps
+
+    @property
+    def target_bpp(self) -> float:
+        return self._target_bpp
+
+    @property
+    def target_factors(self) -> List[float]:
+        return self._target_factors
+
+    @property
+    def target_steps(self) -> List[int]:
+        return self._target_steps
+
+    @property
+    def lam_levels(self) -> Tuple[float, float]:
+        return self._lam_levels
+
+    @property
+    def lam2_factors(self) -> List[float]:
+        return self._lam2_factors
+
+    @property
+    def lam2_steps(self) -> List[int]:
+        return self._lam2_steps

--- a/tests/loss_fn/test_binary_cross_entropy.py
+++ b/tests/loss_fn/test_binary_cross_entropy.py
@@ -1,0 +1,49 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+
+from neuralcompression.loss_fn import (
+    BinaryCrossentropyDiscriminatorLoss,
+    BinaryCrossentropyGeneratorLoss,
+)
+
+
+@pytest.fixture(params=[(3, 5), (3, 6, 6), (5, 3, 64, 64)])
+def binary_logits(request):
+    rng = torch.Generator()
+    rng.manual_seed(int(torch.prod(torch.tensor(request.param))))
+
+    logits1 = torch.randn(size=request.param, generator=rng)
+    logits2 = torch.randn(size=request.param, generator=rng)
+    target = torch.ones_like(logits1)
+
+    return logits1, logits2, target
+
+
+def test_binary_cross_entropy_disc(binary_logits):
+    logits1, logits2, target = binary_logits
+
+    loss_fn = BinaryCrossentropyDiscriminatorLoss()
+
+    output = loss_fn(logits1, logits2, target)
+
+    est1 = -1.0 * torch.log(torch.sigmoid(logits1)).mean()
+    est2 = -1.0 * torch.log(1 - torch.sigmoid(logits2)).mean()
+
+    assert torch.allclose(output, 0.5 * (est1 + est2))
+
+
+def test_binary_cross_entropy_gen(binary_logits):
+    logits1, _, target = binary_logits
+
+    loss_fn = BinaryCrossentropyGeneratorLoss()
+
+    output = loss_fn(logits1, target)
+
+    est1 = -1.0 * torch.log(torch.sigmoid(logits1)).mean()
+
+    assert torch.allclose(output, est1)

--- a/tests/loss_fn/test_mse_loss.py
+++ b/tests/loss_fn/test_mse_loss.py
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+
+from neuralcompression.loss_fn import MSELoss
+
+
+@pytest.mark.parametrize("mse_param", [255.0**2, 1.0, 0.5])
+def test_mse_loss(mse_param, arange_4d_image):
+    rng = torch.Generator()
+    rng.manual_seed(int(torch.prod(torch.tensor(arange_4d_image.shape))))
+
+    img = torch.randn(size=arange_4d_image.shape, generator=rng)
+
+    loss_fn = MSELoss(mse_param)
+
+    output = loss_fn(img, arange_4d_image)
+
+    est = mse_param * torch.mean((img - arange_4d_image) ** 2)
+
+    assert torch.allclose(output, est)

--- a/tests/loss_fn/test_mse_lpips_loss.py
+++ b/tests/loss_fn/test_mse_lpips_loss.py
@@ -1,0 +1,44 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch
+
+from neuralcompression.loss_fn import MSELPIPSLoss, NormFixLPIPS
+
+
+@pytest.mark.parametrize("shape", [(3, 3, 32, 32)])
+@pytest.mark.parametrize("backbone", ["alex", "vgg"])
+@pytest.mark.parametrize("mse_param", [255.0**2, 1.0])
+@pytest.mark.parametrize("lpips_param", [1.0, 0.5])
+def test_mse_lpips_loss(shape, backbone, mse_param, lpips_param):
+    normalize = True
+    rng = torch.Generator()
+    rng.manual_seed(int(torch.prod(torch.tensor(shape))))
+
+    base_img = torch.rand(size=shape, generator=rng)
+    img = torch.rand(size=shape, generator=rng)
+
+    if not normalize:
+        base_img = base_img * 2.0 - 1.0
+        img = img * 2.0 - 1.0
+
+    loss_fn = MSELPIPSLoss(
+        mse_param=mse_param,
+        lpips_param=lpips_param,
+        backbone=backbone,
+        normalize=normalize,
+    )
+    output = loss_fn(img, base_img)
+
+    lpips_model = NormFixLPIPS(net=backbone).eval()
+    for p in lpips_model.parameters():
+        p.requires_grad_(False)
+    est = (
+        mse_param * torch.mean((img - base_img) ** 2)
+        + lpips_param * lpips_model(img, base_img, normalize=normalize).mean()
+    )
+
+    assert torch.allclose(output, est)

--- a/tests/loss_fn/test_oasis_loss.py
+++ b/tests/loss_fn/test_oasis_loss.py
@@ -1,0 +1,61 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import pytest
+import torch.nn.functional as F
+import torch
+
+from neuralcompression.loss_fn import (
+    OASISDiscriminatorLoss,
+    OASISGeneratorLoss,
+)
+
+
+@pytest.fixture(params=[(3, 256, 4, 4), (20, 4, 12, 12), (5, 5, 64, 64)])
+def oasis_logits(request):
+    shape = request.param
+    rng = torch.Generator()
+    rng.manual_seed(int(torch.prod(torch.tensor(shape))))
+
+    target_shape = (shape[0],) + shape[2:]
+
+    logits1 = torch.randn(size=shape, generator=rng)
+    logits2 = torch.randn(size=shape, generator=rng)
+    target = torch.randint(low=0, high=shape[1] - 1, size=target_shape)
+
+    return logits1, logits2, target
+
+
+def test_binary_cross_entropy_disc(oasis_logits):
+    logits1, logits2, target = oasis_logits
+
+    loss_fn = OASISDiscriminatorLoss()
+
+    output = loss_fn(logits1, logits2, target)
+
+    est1 = torch.gather(
+        -1.0 * F.log_softmax(logits1, dim=1), 1, target.unsqueeze(1) + 1
+    ).mean()
+    est2 = torch.gather(
+        -1.0 * F.log_softmax(logits1, dim=1), 1, torch.zeros_like(target).unsqueeze(1)
+    ).mean()
+
+    # numerical precision issues
+    assert torch.allclose(output, 0.5 * (est1 + est2), rtol=0.01)
+
+
+def test_binary_cross_entropy_gen(oasis_logits):
+    logits1, _, target = oasis_logits
+
+    loss_fn = OASISGeneratorLoss()
+
+    output = loss_fn(logits1, target)
+
+    est1 = torch.gather(
+        -1.0 * F.log_softmax(logits1, dim=1), 1, target.unsqueeze(1) + 1
+    ).mean()
+
+    # numerical precision issues
+    assert torch.allclose(output, est1, rtol=0.01)

--- a/tests/loss_fn/test_oasis_loss.py
+++ b/tests/loss_fn/test_oasis_loss.py
@@ -4,13 +4,10 @@
 # LICENSE file in the root directory of this source tree.
 
 import pytest
-import torch.nn.functional as F
 import torch
+import torch.nn.functional as F
 
-from neuralcompression.loss_fn import (
-    OASISDiscriminatorLoss,
-    OASISGeneratorLoss,
-)
+from neuralcompression.loss_fn import OASISDiscriminatorLoss, OASISGeneratorLoss
 
 
 @pytest.fixture(params=[(3, 256, 4, 4), (20, 4, 12, 12), (5, 5, 64, 64)])


### PR DESCRIPTION
This PR includes a suite of loss function refactors. Loss functions for training models are pulled out of the `metrics` submodule and into the new `loss_fn` submodule. This provides a more clear delineation of intended purpose. It also allows separate implementations, which is useful for LPIPS, where we need divide-by-0 protection for the loss, but not for the metric.

Tests are included for all metrics. The normalized LPIPS loss is tested implicitly with the MSE-LPIPS loss.

Losses include:
- Non-saturating GAN loss
- OASIS losses
- MSE loss
- MSE-LPIPS loss