### PR TITLE
fix the bug of using optical_flow_to_color in train.py

### DIFF
--- a/projects/deep_video_compression/train.py
+++ b/projects/deep_video_compression/train.py
@@ -53,9 +53,7 @@ class WandbImageCallback(pl.Callback):
                 mosaic = torch.cat(image_dict[key], dim=-1)
                 mosaic = torch.cat(list(mosaic), dim=-2)
                 if key == "flow":
-                    mosaic = optical_flow_to_color(
-                        mosaic.unsqueeze(0)
-                    )[0]
+                    mosaic = optical_flow_to_color(mosaic.unsqueeze(0))[0]
                 mosaic = torch.clip(mosaic, min=0, max=1.0)
                 trainer.logger.experiment.log(
                     {

--- a/projects/deep_video_compression/train.py
+++ b/projects/deep_video_compression/train.py
@@ -5,7 +5,7 @@
 
 from pathlib import Path
 
-import _optical_flow_to_color
+from neuralcompression.functional import optical_flow_to_color
 import hydra
 import numpy as np
 import pytorch_lightning as pl
@@ -53,7 +53,7 @@ class WandbImageCallback(pl.Callback):
                 mosaic = torch.cat(image_dict[key], dim=-1)
                 mosaic = torch.cat(list(mosaic), dim=-2)
                 if key == "flow":
-                    mosaic = _optical_flow_to_color.optical_flow_to_color(
+                    mosaic = optical_flow_to_color(
                         mosaic.unsqueeze(0)
                     )[0]
                 mosaic = torch.clip(mosaic, min=0, max=1.0)

--- a/projects/deep_video_compression/train.py
+++ b/projects/deep_video_compression/train.py
@@ -4,8 +4,6 @@
 # LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
-
-from neuralcompression.functional import optical_flow_to_color
 import hydra
 import numpy as np
 import pytorch_lightning as pl
@@ -16,7 +14,7 @@ from dvc_module import DvcModule
 from omegaconf import DictConfig, OmegaConf
 from pytorch_lightning.callbacks import LearningRateMonitor, ModelCheckpoint
 from pytorch_lightning.loggers import WandbLogger
-
+from neuralcompression.functional import optical_flow_to_color
 from neuralcompression.models import DVC
 
 

--- a/projects/deep_video_compression/train.py
+++ b/projects/deep_video_compression/train.py
@@ -4,16 +4,18 @@
 # LICENSE file in the root directory of this source tree.
 
 from pathlib import Path
+
 import hydra
 import numpy as np
-import pytorch_lightning as pl
 import torch
 import wandb
 from data_module import Vimeo90kSeptupletLightning
 from dvc_module import DvcModule
 from omegaconf import DictConfig, OmegaConf
+from pytorch_lightning import pl
 from pytorch_lightning.callbacks import LearningRateMonitor, ModelCheckpoint
 from pytorch_lightning.loggers import WandbLogger
+
 from neuralcompression.functional import optical_flow_to_color
 from neuralcompression.models import DVC
 

--- a/projects/deep_video_compression/train.py
+++ b/projects/deep_video_compression/train.py
@@ -7,12 +7,12 @@ from pathlib import Path
 
 import hydra
 import numpy as np
+import pytorch_lightning as pl
 import torch
 import wandb
 from data_module import Vimeo90kSeptupletLightning
 from dvc_module import DvcModule
 from omegaconf import DictConfig, OmegaConf
-from pytorch_lightning import pl
 from pytorch_lightning.callbacks import LearningRateMonitor, ModelCheckpoint
 from pytorch_lightning.loggers import WandbLogger
 


### PR DESCRIPTION
Closes #<!-- The issue that corresponds to the changes. -->

## Changes

<!-- A brief description of the changes. -->

Change the import of optical_flow_to_color function from `import _optical_flow_to_color` to `from neuralcompression.functional import optical_flow_to_color`.

Change the function call `_optical_flow_to_color.optical_flow_to_color` to `optical_flow_to_color`