### PR TITLE
Add model zoo and MS-ILLM pretrained weights

### DIFF
--- a/hubconf.py
+++ b/hubconf.py
@@ -1,0 +1,230 @@
+dependencies = ["torch"]
+
+from neuralcompression.zoo import msillm_quality_1 as _msillm_quality_1
+from neuralcompression.zoo import msillm_quality_2 as _msillm_quality_2
+from neuralcompression.zoo import msillm_quality_3 as _msillm_quality_3
+from neuralcompression.zoo import msillm_quality_4 as _msillm_quality_4
+from neuralcompression.zoo import msillm_quality_5 as _msillm_quality_5
+from neuralcompression.zoo import msillm_quality_6 as _msillm_quality_6
+from neuralcompression.zoo import noganms_quality_1 as _noganms_quality_1
+from neuralcompression.zoo import noganms_quality_2 as _noganms_quality_2
+from neuralcompression.zoo import noganms_quality_3 as _noganms_quality_3
+from neuralcompression.zoo import noganms_quality_4 as _noganms_quality_4
+from neuralcompression.zoo import noganms_quality_5 as _noganms_quality_5
+from neuralcompression.zoo import noganms_quality_6 as _noganms_quality_6
+
+
+def msillm_quality_1(pretrained=False, **kwargs):
+    """
+    Pretrained MS-ILLM model
+
+    This model was trained for the paper:
+
+    MJ Muckley, A El-Nouby, K Ullrich, H Jegou, J Verbeek.
+    Improving Statistical Fidelity for Neural Image Compression with Implicit
+    Local Likelihood Models. In *ICML*, 2023.
+
+    The target bitrate is 0.035 bits per pixel
+
+    pretrained (bool): kwargs, load pretrained weights into the model
+    """
+
+    return _msillm_quality_1(pretrained=pretrained, **kwargs)
+
+
+def msillm_quality_2(pretrained=False, **kwargs):
+    """
+    Pretrained MS-ILLM model
+
+    This model was trained for the paper:
+
+    MJ Muckley, A El-Nouby, K Ullrich, H Jegou, J Verbeek.
+    Improving Statistical Fidelity for Neural Image Compression with Implicit
+    Local Likelihood Models. In *ICML*, 2023.
+
+    The target bitrate is 0.07 bits per pixel
+
+    pretrained (bool): kwargs, load pretrained weights into the model
+    """
+
+    return _msillm_quality_2(pretrained=pretrained, **kwargs)
+
+
+def msillm_quality_3(pretrained=False, **kwargs):
+    """
+    Pretrained MS-ILLM model
+
+    This model was trained for the paper:
+
+    MJ Muckley, A El-Nouby, K Ullrich, H Jegou, J Verbeek.
+    Improving Statistical Fidelity for Neural Image Compression with Implicit
+    Local Likelihood Models. In *ICML*, 2023.
+
+    The target bitrate is 0.14 bits per pixel
+
+    pretrained (bool): kwargs, load pretrained weights into the model
+    """
+
+    return _msillm_quality_3(pretrained=pretrained, **kwargs)
+
+
+def msillm_quality_4(pretrained=False, **kwargs):
+    """
+    Pretrained MS-ILLM model
+
+    This model was trained for the paper:
+
+    MJ Muckley, A El-Nouby, K Ullrich, H Jegou, J Verbeek.
+    Improving Statistical Fidelity for Neural Image Compression with Implicit
+    Local Likelihood Models. In *ICML*, 2023.
+
+    The target bitrate is 0.3 bits per pixel
+
+    pretrained (bool): kwargs, load pretrained weights into the model
+    """
+
+    return _msillm_quality_4(pretrained=pretrained, **kwargs)
+
+
+def msillm_quality_5(pretrained=False, **kwargs):
+    """
+    Pretrained MS-ILLM model
+
+    This model was trained for the paper:
+
+    MJ Muckley, A El-Nouby, K Ullrich, H Jegou, J Verbeek.
+    Improving Statistical Fidelity for Neural Image Compression with Implicit
+    Local Likelihood Models. In *ICML*, 2023.
+
+    The target bitrate is 0.45 bits per pixel
+
+    pretrained (bool): kwargs, load pretrained weights into the model
+    """
+
+    return _msillm_quality_5(pretrained=pretrained, **kwargs)
+
+
+def msillm_quality_6(pretrained=False, **kwargs):
+    """
+    Pretrained MS-ILLM model
+
+    This model was trained for the paper:
+
+    MJ Muckley, A El-Nouby, K Ullrich, H Jegou, J Verbeek.
+    Improving Statistical Fidelity for Neural Image Compression with Implicit
+    Local Likelihood Models. In *ICML*, 2023.
+
+    The target bitrate is 0.9 bits per pixel
+
+    pretrained (bool): kwargs, load pretrained weights into the model
+    """
+
+    return _msillm_quality_6(pretrained=pretrained, **kwargs)
+
+
+def noganms_quality_1(pretrained=False, **kwargs):
+    """
+    Pretrained No-GAN model with HiFiC Mean-Scale Hyperprior architecture.
+
+    This model was trained for the paper:
+
+    MJ Muckley, A El-Nouby, K Ullrich, H Jegou, J Verbeek.
+    Improving Statistical Fidelity for Neural Image Compression with Implicit
+    Local Likelihood Models. In *ICML*, 2023.
+
+    The target bitrate is 0.035 bits per pixel
+
+    pretrained (bool): kwargs, load pretrained weights into the model
+    """
+
+    return _noganms_quality_1(pretrained=pretrained, **kwargs)
+
+
+def noganms_quality_2(pretrained=False, **kwargs):
+    """
+    Pretrained No-GAN model with HiFiC Mean-Scale Hyperprior architecture.
+
+    This model was trained for the paper:
+
+    MJ Muckley, A El-Nouby, K Ullrich, H Jegou, J Verbeek.
+    Improving Statistical Fidelity for Neural Image Compression with Implicit
+    Local Likelihood Models. In *ICML*, 2023.
+
+    The target bitrate is 0.07 bits per pixel
+
+    pretrained (bool): kwargs, load pretrained weights into the model
+    """
+
+    return _noganms_quality_2(pretrained=pretrained, **kwargs)
+
+
+def noganms_quality_3(pretrained=False, **kwargs):
+    """
+    Pretrained No-GAN model with HiFiC Mean-Scale Hyperprior architecture.
+
+    This model was trained for the paper:
+
+    MJ Muckley, A El-Nouby, K Ullrich, H Jegou, J Verbeek.
+    Improving Statistical Fidelity for Neural Image Compression with Implicit
+    Local Likelihood Models. In *ICML*, 2023.
+
+    The target bitrate is 0.14 bits per pixel
+
+    pretrained (bool): kwargs, load pretrained weights into the model
+    """
+
+    return _noganms_quality_3(pretrained=pretrained, **kwargs)
+
+
+def noganms_quality_4(pretrained=False, **kwargs):
+    """
+    Pretrained No-GAN model with HiFiC Mean-Scale Hyperprior architecture.
+
+    This model was trained for the paper:
+
+    MJ Muckley, A El-Nouby, K Ullrich, H Jegou, J Verbeek.
+    Improving Statistical Fidelity for Neural Image Compression with Implicit
+    Local Likelihood Models. In *ICML*, 2023.
+
+    The target bitrate is 0.3 bits per pixel
+
+    pretrained (bool): kwargs, load pretrained weights into the model
+    """
+
+    return _noganms_quality_4(pretrained=pretrained, **kwargs)
+
+
+def noganms_quality_5(pretrained=False, **kwargs):
+    """
+    Pretrained No-GAN model with HiFiC Mean-Scale Hyperprior architecture.
+
+    This model was trained for the paper:
+
+    MJ Muckley, A El-Nouby, K Ullrich, H Jegou, J Verbeek.
+    Improving Statistical Fidelity for Neural Image Compression with Implicit
+    Local Likelihood Models. In *ICML*, 2023.
+
+    The target bitrate is 0.45 bits per pixel
+
+    pretrained (bool): kwargs, load pretrained weights into the model
+    """
+
+    return _noganms_quality_5(pretrained=pretrained, **kwargs)
+
+
+def noganms_quality_6(pretrained=False, **kwargs):
+    """
+    Pretrained No-GAN model with HiFiC Mean-Scale Hyperprior architecture.
+
+    This model was trained for the paper:
+
+    MJ Muckley, A El-Nouby, K Ullrich, H Jegou, J Verbeek.
+    Improving Statistical Fidelity for Neural Image Compression with Implicit
+    Local Likelihood Models. In *ICML*, 2023.
+
+    The target bitrate is 0.9 bits per pixel
+
+    pretrained (bool): kwargs, load pretrained weights into the model
+    """
+
+    return _noganms_quality_6(pretrained=pretrained, **kwargs)

--- a/hubconf.py
+++ b/hubconf.py
@@ -57,7 +57,7 @@ def msillm_quality_2(pretrained=True, **kwargs):
 
 
 def msillm_quality_3(pretrained=True, **kwargs):
-    """
+    r"""
     Pretrained MS-ILLM model
 
     This model was trained for the paper:

--- a/hubconf.py
+++ b/hubconf.py
@@ -14,7 +14,7 @@ from neuralcompression.zoo import noganms_quality_5 as _noganms_quality_5
 from neuralcompression.zoo import noganms_quality_6 as _noganms_quality_6
 
 
-def msillm_quality_1(pretrained=False, **kwargs):
+def msillm_quality_1(pretrained=True, **kwargs):
     """
     Pretrained MS-ILLM model
 
@@ -32,7 +32,7 @@ def msillm_quality_1(pretrained=False, **kwargs):
     return _msillm_quality_1(pretrained=pretrained, **kwargs)
 
 
-def msillm_quality_2(pretrained=False, **kwargs):
+def msillm_quality_2(pretrained=True, **kwargs):
     """
     Pretrained MS-ILLM model
 
@@ -50,7 +50,7 @@ def msillm_quality_2(pretrained=False, **kwargs):
     return _msillm_quality_2(pretrained=pretrained, **kwargs)
 
 
-def msillm_quality_3(pretrained=False, **kwargs):
+def msillm_quality_3(pretrained=True, **kwargs):
     """
     Pretrained MS-ILLM model
 
@@ -68,7 +68,7 @@ def msillm_quality_3(pretrained=False, **kwargs):
     return _msillm_quality_3(pretrained=pretrained, **kwargs)
 
 
-def msillm_quality_4(pretrained=False, **kwargs):
+def msillm_quality_4(pretrained=True, **kwargs):
     """
     Pretrained MS-ILLM model
 
@@ -86,7 +86,7 @@ def msillm_quality_4(pretrained=False, **kwargs):
     return _msillm_quality_4(pretrained=pretrained, **kwargs)
 
 
-def msillm_quality_5(pretrained=False, **kwargs):
+def msillm_quality_5(pretrained=True, **kwargs):
     """
     Pretrained MS-ILLM model
 
@@ -104,7 +104,7 @@ def msillm_quality_5(pretrained=False, **kwargs):
     return _msillm_quality_5(pretrained=pretrained, **kwargs)
 
 
-def msillm_quality_6(pretrained=False, **kwargs):
+def msillm_quality_6(pretrained=True, **kwargs):
     """
     Pretrained MS-ILLM model
 
@@ -122,7 +122,7 @@ def msillm_quality_6(pretrained=False, **kwargs):
     return _msillm_quality_6(pretrained=pretrained, **kwargs)
 
 
-def noganms_quality_1(pretrained=False, **kwargs):
+def noganms_quality_1(pretrained=True, **kwargs):
     """
     Pretrained No-GAN model with HiFiC Mean-Scale Hyperprior architecture.
 
@@ -140,7 +140,7 @@ def noganms_quality_1(pretrained=False, **kwargs):
     return _noganms_quality_1(pretrained=pretrained, **kwargs)
 
 
-def noganms_quality_2(pretrained=False, **kwargs):
+def noganms_quality_2(pretrained=True, **kwargs):
     """
     Pretrained No-GAN model with HiFiC Mean-Scale Hyperprior architecture.
 
@@ -158,7 +158,7 @@ def noganms_quality_2(pretrained=False, **kwargs):
     return _noganms_quality_2(pretrained=pretrained, **kwargs)
 
 
-def noganms_quality_3(pretrained=False, **kwargs):
+def noganms_quality_3(pretrained=True, **kwargs):
     """
     Pretrained No-GAN model with HiFiC Mean-Scale Hyperprior architecture.
 
@@ -176,7 +176,7 @@ def noganms_quality_3(pretrained=False, **kwargs):
     return _noganms_quality_3(pretrained=pretrained, **kwargs)
 
 
-def noganms_quality_4(pretrained=False, **kwargs):
+def noganms_quality_4(pretrained=True, **kwargs):
     """
     Pretrained No-GAN model with HiFiC Mean-Scale Hyperprior architecture.
 
@@ -194,7 +194,7 @@ def noganms_quality_4(pretrained=False, **kwargs):
     return _noganms_quality_4(pretrained=pretrained, **kwargs)
 
 
-def noganms_quality_5(pretrained=False, **kwargs):
+def noganms_quality_5(pretrained=True, **kwargs):
     """
     Pretrained No-GAN model with HiFiC Mean-Scale Hyperprior architecture.
 
@@ -212,7 +212,7 @@ def noganms_quality_5(pretrained=False, **kwargs):
     return _noganms_quality_5(pretrained=pretrained, **kwargs)
 
 
-def noganms_quality_6(pretrained=False, **kwargs):
+def noganms_quality_6(pretrained=True, **kwargs):
     """
     Pretrained No-GAN model with HiFiC Mean-Scale Hyperprior architecture.
 

--- a/hubconf.py
+++ b/hubconf.py
@@ -1,4 +1,8 @@
-dependencies = ["torch"]
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 
 from neuralcompression.zoo import msillm_quality_1 as _msillm_quality_1
 from neuralcompression.zoo import msillm_quality_2 as _msillm_quality_2
@@ -12,6 +16,8 @@ from neuralcompression.zoo import noganms_quality_3 as _noganms_quality_3
 from neuralcompression.zoo import noganms_quality_4 as _noganms_quality_4
 from neuralcompression.zoo import noganms_quality_5 as _noganms_quality_5
 from neuralcompression.zoo import noganms_quality_6 as _noganms_quality_6
+
+dependencies = ["torch"]
 
 
 def msillm_quality_1(pretrained=True, **kwargs):

--- a/neuralcompression/zoo/__init__.py
+++ b/neuralcompression/zoo/__init__.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from ._msillm import (
     msillm_quality_1,
     msillm_quality_2,

--- a/neuralcompression/zoo/__init__.py
+++ b/neuralcompression/zoo/__init__.py
@@ -1,0 +1,16 @@
+from ._msillm import (
+    msillm_quality_1,
+    msillm_quality_2,
+    msillm_quality_3,
+    msillm_quality_4,
+    msillm_quality_5,
+    msillm_quality_6,
+)
+from ._noganms import (
+    noganms_quality_1,
+    noganms_quality_2,
+    noganms_quality_3,
+    noganms_quality_4,
+    noganms_quality_5,
+    noganms_quality_6,
+)

--- a/neuralcompression/zoo/_msillm.py
+++ b/neuralcompression/zoo/_msillm.py
@@ -22,13 +22,13 @@ QUALITIES = [1, 2, 3, 4, 5, 6]
 
 
 def _build_msillm(weights: Optional[str] = None):
-    if weights not in VALID_WEIGHTS:
-        raise ValueError(
-            f"Unrecognized weights {weights}, must be one of {VALID_WEIGHTS}"
-        )
-
     model = HiFiCAutoencoder()
     if weights is not None:
+        if weights not in VALID_WEIGHTS:
+            raise ValueError(
+                f"Unrecognized weights {weights}, must be one of {VALID_WEIGHTS}"
+            )
+
         url = (
             "https://dl.fbaipublicfiles.com/NeuralCompression/2023-muckley-msillm/"
             + f"msillm_{weights}.ckpt"

--- a/neuralcompression/zoo/_msillm.py
+++ b/neuralcompression/zoo/_msillm.py
@@ -18,8 +18,6 @@ VALID_WEIGHTS = [
     "target_0.9bpp",
 ]
 
-QUALITIES = [1, 2, 3, 4, 5, 6]
-
 
 def _build_msillm(weights: Optional[str] = None):
     model = HiFiCAutoencoder()

--- a/neuralcompression/zoo/_msillm.py
+++ b/neuralcompression/zoo/_msillm.py
@@ -34,7 +34,9 @@ def _build_msillm(weights: Optional[str] = None):
             + f"msillm_{weights}.ckpt"
         )
 
-        model.load_state_dict(torch.hub.load_state_dict_from_url(url))
+        model.load_state_dict(
+            torch.hub.load_state_dict_from_url(url, map_location="cpu")
+        )
 
     return model
 

--- a/neuralcompression/zoo/_msillm.py
+++ b/neuralcompression/zoo/_msillm.py
@@ -1,0 +1,88 @@
+from typing import Optional
+
+import torch
+
+from neuralcompression.models import HiFiCAutoencoder
+
+VALID_WEIGHTS = [
+    "target_0.035bpp",
+    "target_0.07bpp",
+    "target_0.14bpp",
+    "target_0.3bpp",
+    "target_0.45bpp",
+    "target_0.9bpp",
+]
+
+QUALITIES = [1, 2, 3, 4, 5, 6]
+
+
+def _build_msillm(weights: Optional[str] = None):
+    if weights not in VALID_WEIGHTS:
+        raise ValueError(
+            f"Unrecognized weights {weights}, must be one of {VALID_WEIGHTS}"
+        )
+
+    model = HiFiCAutoencoder()
+    if weights is not None:
+        url = (
+            "https://dl.fbaipublicfiles.com/NeuralCompression/2023-muckley-msillm/"
+            + f"msillm_{weights}.ckpt"
+        )
+
+        model.load_state_dict(torch.hub.load_state_dict_from_url(url))
+
+    return model
+
+
+def msillm_quality_1(pretrained=False, **kwargs):
+    if pretrained is True:
+        weights = "target_0.035bpp"
+    else:
+        weights = None
+
+    return _build_msillm(weights=weights)
+
+
+def msillm_quality_2(pretrained=False, **kwargs):
+    if pretrained is True:
+        weights = "target_0.07bpp"
+    else:
+        weights = None
+
+    return _build_msillm(weights=weights)
+
+
+def msillm_quality_3(pretrained=False, **kwargs):
+    if pretrained is True:
+        weights = "target_0.14bpp"
+    else:
+        weights = None
+
+    return _build_msillm(weights=weights)
+
+
+def msillm_quality_4(pretrained=False, **kwargs):
+    if pretrained is True:
+        weights = "target_0.3bpp"
+    else:
+        weights = None
+
+    return _build_msillm(weights=weights)
+
+
+def msillm_quality_5(pretrained=False, **kwargs):
+    if pretrained is True:
+        weights = "target_0.455bpp"
+    else:
+        weights = None
+
+    return _build_msillm(weights=weights)
+
+
+def msillm_quality_6(pretrained=False, **kwargs):
+    if pretrained is True:
+        weights = "target_0.9bpp"
+    else:
+        weights = None
+
+    return _build_msillm(weights=weights)

--- a/neuralcompression/zoo/_msillm.py
+++ b/neuralcompression/zoo/_msillm.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Optional
 
 import torch

--- a/neuralcompression/zoo/_noganms.py
+++ b/neuralcompression/zoo/_noganms.py
@@ -1,0 +1,88 @@
+from typing import Optional
+
+import torch
+
+from neuralcompression.models import HiFiCAutoencoder
+
+VALID_WEIGHTS = [
+    "target_0.035bpp",
+    "target_0.07bpp",
+    "target_0.14bpp",
+    "target_0.3bpp",
+    "target_0.45bpp",
+    "target_0.9bpp",
+]
+
+QUALITIES = [1, 2, 3, 4, 5, 6]
+
+
+def _build_noganms(weights: Optional[str] = None):
+    if weights not in VALID_WEIGHTS:
+        raise ValueError(
+            f"Unrecognized weights {weights}, must be one of {VALID_WEIGHTS}"
+        )
+
+    model = HiFiCAutoencoder()
+    if weights is not None:
+        url = (
+            "https://dl.fbaipublicfiles.com/NeuralCompression/2023-muckley-msillm/"
+            + f"noganms_{weights}.ckpt"
+        )
+
+        model.load_state_dict(torch.hub.load_state_dict_from_url(url))
+
+    return model
+
+
+def noganms_quality_1(pretrained=False, **kwargs):
+    if pretrained is True:
+        weights = "target_0.035bpp"
+    else:
+        weights = None
+
+    return _build_noganms(weights=weights)
+
+
+def noganms_quality_2(pretrained=False, **kwargs):
+    if pretrained is True:
+        weights = "target_0.07bpp"
+    else:
+        weights = None
+
+    return _build_noganms(weights=weights)
+
+
+def noganms_quality_3(pretrained=False, **kwargs):
+    if pretrained is True:
+        weights = "target_0.14bpp"
+    else:
+        weights = None
+
+    return _build_noganms(weights=weights)
+
+
+def noganms_quality_4(pretrained=False, **kwargs):
+    if pretrained is True:
+        weights = "target_0.3bpp"
+    else:
+        weights = None
+
+    return _build_noganms(weights=weights)
+
+
+def noganms_quality_5(pretrained=False, **kwargs):
+    if pretrained is True:
+        weights = "target_0.455bpp"
+    else:
+        weights = None
+
+    return _build_noganms(weights=weights)
+
+
+def noganms_quality_6(pretrained=False, **kwargs):
+    if pretrained is True:
+        weights = "target_0.9bpp"
+    else:
+        weights = None
+
+    return _build_noganms(weights=weights)

--- a/neuralcompression/zoo/_noganms.py
+++ b/neuralcompression/zoo/_noganms.py
@@ -34,7 +34,9 @@ def _build_noganms(weights: Optional[str] = None):
             + f"noganms_{weights}.ckpt"
         )
 
-        model.load_state_dict(torch.hub.load_state_dict_from_url(url))
+        model.load_state_dict(
+            torch.hub.load_state_dict_from_url(url, map_location="cpu")
+        )
 
     return model
 

--- a/neuralcompression/zoo/_noganms.py
+++ b/neuralcompression/zoo/_noganms.py
@@ -22,13 +22,13 @@ QUALITIES = [1, 2, 3, 4, 5, 6]
 
 
 def _build_noganms(weights: Optional[str] = None):
-    if weights not in VALID_WEIGHTS:
-        raise ValueError(
-            f"Unrecognized weights {weights}, must be one of {VALID_WEIGHTS}"
-        )
-
     model = HiFiCAutoencoder()
     if weights is not None:
+        if weights not in VALID_WEIGHTS:
+            raise ValueError(
+                f"Unrecognized weights {weights}, must be one of {VALID_WEIGHTS}"
+            )
+
         url = (
             "https://dl.fbaipublicfiles.com/NeuralCompression/2023-muckley-msillm/"
             + f"noganms_{weights}.ckpt"

--- a/neuralcompression/zoo/_noganms.py
+++ b/neuralcompression/zoo/_noganms.py
@@ -18,8 +18,6 @@ VALID_WEIGHTS = [
     "target_0.9bpp",
 ]
 
-QUALITIES = [1, 2, 3, 4, 5, 6]
-
 
 def _build_noganms(weights: Optional[str] = None):
     model = HiFiCAutoencoder()

--- a/neuralcompression/zoo/_noganms.py
+++ b/neuralcompression/zoo/_noganms.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 from typing import Optional
 
 import torch

--- a/projects/illm/README.md
+++ b/projects/illm/README.md
@@ -36,7 +36,27 @@ pip install -r requirements.txt
 
 ## Pretrained Models
 
-This repository is configured to use `torch.hub`.
+This repository is configured to use `torch.hub`. An example for loading the
+ILLM model targeting 0.14 bpp is shown below:
+
+```python
+import torch
+
+model = torch.hub.load("facebookresearch/NeuralCompression", "msillm_quality_3")
+```
+
+To list all available models, you can use:
+
+```python
+torch.hub.list("facebookresearch/NeuralCompression")
+```
+
+To get information on a model and its target bitrate, you can use:
+
+```python
+torch.hub.help("facebookresearch/NeuralCompression", "msillm_quality_3")
+```
+
 
 ## Training
 

--- a/projects/illm/README.md
+++ b/projects/illm/README.md
@@ -1,4 +1,4 @@
-# Official implementation of MS-ILLM
+# Official Implementation of MS-ILLM
 
 This is the official code for the following paper:
 
@@ -33,6 +33,10 @@ directory:
 ```bash
 pip install -r requirements.txt
 ```
+
+## Pretrained Models
+
+This repository is configured to use `torch.hub`.
 
 ## Training
 

--- a/projects/illm/README.md
+++ b/projects/illm/README.md
@@ -54,9 +54,22 @@ torch.hub.list("facebookresearch/NeuralCompression")
 To get information on a model and its target bitrate, you can use:
 
 ```python
-torch.hub.help("facebookresearch/NeuralCompression", "msillm_quality_3")
+print(torch.hub.help("facebookresearch/NeuralCompression", "msillm_quality_3"))
 ```
 
+We release the following models:
+
+| Bitrate   | MS-ILLM            | No-GAN              |
+| --------- | ------------------ | ------------------- |
+| 0.035 bpp | "msillm_quality_1" | "noganms_quality_1" |
+| 0.07 bpp  | "msillm_quality_2" | "noganms_quality_2" |
+| 0.14 bpp  | "msillm_quality_3" | "noganms_quality_3" |
+| 0.3 bpp   | "msillm_quality_4" | "noganms_quality_4" |
+| 0.45 bpp  | "msillm_quality_5" | "noganms_quality_5" |
+| 0.9 bpp   | "msillm_quality_6" | "noganms_quality_6" |
+
+The No-GAN models are released for researchers seeking to fine-tune them
+with their own methods.
 
 ## Training
 

--- a/projects/illm/README.md
+++ b/projects/illm/README.md
@@ -71,6 +71,18 @@ We release the following models:
 The No-GAN models are released for researchers seeking to fine-tune them
 with their own methods.
 
+## Reproducing Results
+
+The `eval_folder_example.py` script provides an example for reproducing the
+numbers from the paper. Simply run
+
+```bash
+python eval_folder_example.py $PATH_TO_CLIC2020
+```
+
+And it should run on the folder you provide and print the metrics for the
+0.14 bpp target model.
+
 ## Training
 
 This code makes heavy use of

--- a/projects/illm/eval_folder_example.py
+++ b/projects/illm/eval_folder_example.py
@@ -1,0 +1,108 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from argparse import ArgumentParser
+from pathlib import Path
+
+import torch
+from PIL import Image
+from torch import Tensor
+from torchmetrics.image import (
+    FrechetInceptionDistance,
+    LearnedPerceptualImagePatchSimilarity,
+)
+from torchvision.transforms import ToTensor
+from tqdm import tqdm
+
+from neuralcompression.metrics import (
+    MultiscaleStructuralSimilarity,
+    calc_psnr,
+    pickle_size_of,
+    update_patch_fid,
+)
+
+
+def rescale_image(image: Tensor, back_to_float: bool = True) -> Tensor:
+    dtype = image.dtype
+    image = (image * 255 + 0.5).to(torch.uint8)
+
+    if back_to_float:
+        image = image.to(dtype)
+
+    return image
+
+
+def main():
+    parser = ArgumentParser()
+
+    parser.add_argument("clic_path", type=str, help="path to CLIC2020 directory")
+
+    args = parser.parse_args()
+    clic_path = Path(args.clic_path)
+
+    device = torch.device("cuda")
+    model = torch.hub.load(
+        "facebookresearch/NeuralCompression:mmuckley/illm_zoo",
+        "msillm_quality_3",
+    )
+    model = model.to(device)
+    model = model.eval()
+    model.update()
+    model.update_tensor_devices("compress")
+
+    totensor = ToTensor()
+
+    msssim_metric = MultiscaleStructuralSimilarity(data_range=255.0).to(device)
+    lpips_metric = LearnedPerceptualImagePatchSimilarity().to(device)
+    fid_metric = FrechetInceptionDistance().to(device)
+
+    psnr_vals = []
+    bpp_vals = []
+
+    for image_path in tqdm(list(clic_path.glob("*.png"))):
+        with open(image_path, "rb") as f:
+            image_pil = Image.open(f)
+            image_pil = image_pil.convert("RGB")
+
+        image = totensor(image_pil).unsqueeze(0).to(device)
+
+        with torch.no_grad():
+            compressed = model.compress(image, force_cpu=False)
+            decompressed = model.decompress(compressed, force_cpu=False).clamp(0.0, 1.0)
+
+        num_bytes = pickle_size_of(compressed)
+        bpp = num_bytes * 8 / (image.shape[0] * image.shape[-2] * image.shape[-1])
+        bpp_vals.append(float(bpp))
+
+        orig_image = rescale_image(image)
+        pred_image = rescale_image(decompressed)
+
+        with torch.no_grad():
+            update_patch_fid(image, decompressed, fid_metric)
+
+            orig_image = rescale_image(image)
+            pred_image = rescale_image(decompressed)
+
+            psnr_val = calc_psnr(pred_image, orig_image)
+            psnr_vals.append(float(psnr_val))
+            msssim_metric(pred_image, orig_image)
+            lpips_metric(pred_image, orig_image)
+
+    bpp_total = sum(bpp_vals) / len(bpp_vals)
+    psnr_total = sum(psnr_vals) / len(psnr_vals)
+    msssim_total = float(msssim_metric.compute())
+    lpips_total = float(lpips_metric.compute())
+    fid_total = float(fid_metric.compute())
+
+    print("Compression complete")
+    print(f"Rate: {bpp_total}")
+    print(f"PSNR: {psnr_total}")
+    print(f"MS-SSIM: {msssim_total}")
+    print(f"LPIPS: {lpips_total}")
+    print(f"FID: {fid_total}")
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/illm/eval_folder_example.py
+++ b/projects/illm/eval_folder_example.py
@@ -43,10 +43,7 @@ def main():
     clic_path = Path(args.clic_path)
 
     device = torch.device("cuda")
-    model = torch.hub.load(
-        "facebookresearch/NeuralCompression:mmuckley/illm_zoo",
-        "msillm_quality_3",
-    )
+    model = torch.hub.load("facebookresearch/NeuralCompression", "msillm_quality_3")
     model = model.to(device)
     model = model.eval()
     model.update()


### PR DESCRIPTION
- Upload models to FAIR AWS
- Add description of how to use the models with `torch.hub` to README
- Tested 0.14 bpp model and verified that it reproduces PSNR numbers and FID from the paper
- Add example for how to run the model and reproduce PSNR and FID numbers