### PR TITLE
Update package scripts, required scipy version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,0 @@
-repos:
--   repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-    -   id: black

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include *.md
 include *.cc
 include LICENSE
+include WEIHTS_LICENSE
 include pyproject.toml
 include setup.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -99,7 +99,7 @@ tests =
     pillow==9.4.0
     pytest==7.4.0
     pytorchvideo==0.1.5
-    scipy==1.11.3
+    scipy==1.11.1
     torch==2.0.1
     torchmetrics==1.1.0
     torchvision==0.15.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -99,7 +99,7 @@ tests =
     pillow==9.4.0
     pytest==7.4.0
     pytorchvideo==0.1.5
-    scipy==1.11.1
+    scipy==1.11.3
     torch==2.0.1
     torchmetrics==1.1.0
     torchvision==0.15.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,7 @@ install_requires =
     lpips>=0.1.4
     pillow>=9.4.0
     pytorchvideo>=0.1.5
+    scipy<=1.11.1
     torch>=2.0.1
     torch-fidelity>=0.3.0
     torchmetrics>=1.1.0


### PR DESCRIPTION
This package cleans up some package management files.

It also adds a requirement for a lower version of `scipy` to avoid the error in Issue #217.