### PR TITLE
Remove unnecessary requiements.txt

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -13,8 +13,8 @@ PyPI.
 Using `pip`, you can install the package in development mode by running:
 
 ```sh
+pip install --editable ".[dev]"
 pip install -e .
-pip install -r dev-requirements.txt
 ```
 
 ## Testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
---editable ".[dev, docs]"


### PR DESCRIPTION
`requirements.txt` has been unnecessary for some time due to `setup.cfg`. This PR removes the file to lessen confusion.