### PR TITLE
Remove remote model downloads from CI tests

### DIFF
--- a/neuralcompression/metrics/_dists.py
+++ b/neuralcompression/metrics/_dists.py
@@ -13,7 +13,7 @@ from typing_extensions import Literal
 
 
 class NoTrainDists(_DISTS):
-    def train(self, mode: bool) -> "NoTrainDists":
+    def train(self, mode: bool = True) -> "NoTrainDists":
         """keep network in evaluation mode."""
         return super().train(False)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,3 @@ requires = [
 
 [tool.setuptools_scm]
 write_to = "neuralcompression/version.py"
-
-[isort]
-profile = "black"

--- a/tests/cached_data/create_cached_tensorflow_data.py
+++ b/tests/cached_data/create_cached_tensorflow_data.py
@@ -12,7 +12,7 @@ import torch
 
 
 def create_input(shape, offset: int = 0):
-    x = np.arange(np.product(shape)).reshape(shape) + offset
+    x = np.arange(np.prod(shape)).reshape(shape) + offset
 
     return torch.from_numpy(x).to(torch.get_default_dtype())
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,25 @@
 
 import pytest
 import torch
+import torch.nn as nn
+
+
+class MockBackbone(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.model = nn.Sequential(
+            nn.Conv2d(3, 2048, kernel_size=3, padding=1),
+            nn.AdaptiveAvgPool2d(output_size=(1, 1)),
+        )
+        for param in self.parameters():
+            param.requires_grad_(False)
+
+        self.eval()
+
+    def train(self, mode: bool = True) -> "MockBackbone":
+        """keep network in evaluation mode."""
+        return super().train(False)
 
 
 @pytest.fixture(
@@ -24,3 +43,8 @@ def arange_4d_image_odd(request):
     x = torch.arange(torch.prod(torch.tensor(request.param))).reshape(request.param)
 
     return x.to(torch.get_default_dtype())
+
+
+@pytest.fixture(scope="session")
+def mock_backbone():
+    return MockBackbone()

--- a/tests/metrics/test_dists.py
+++ b/tests/metrics/test_dists.py
@@ -5,6 +5,7 @@
 
 import pytest
 import torch
+from conftest import MockDiffBackbone
 from torch import Tensor
 
 import neuralcompression.metrics._dists
@@ -12,11 +13,13 @@ from neuralcompression.metrics import DeepImageStructureTextureSimilarity
 
 
 @pytest.mark.parametrize("num_samples", [5])
-def test_dists(num_samples: int, arange_4d_image: Tensor, monkeypatch, mock_backbone):
+def test_dists(num_samples: int, arange_4d_image: Tensor, monkeypatch):
     if arange_4d_image.shape[1] != 3:
         return
 
-    monkeypatch.setattr(neuralcompression.metrics._dists, "NoTrainDists", mock_backbone)
+    monkeypatch.setattr(
+        neuralcompression.metrics._dists, "NoTrainDists", MockDiffBackbone
+    )
     metric = DeepImageStructureTextureSimilarity()
 
     for _ in range(num_samples):

--- a/tests/metrics/test_dists.py
+++ b/tests/metrics/test_dists.py
@@ -7,14 +7,16 @@ import pytest
 import torch
 from torch import Tensor
 
+import neuralcompression.metrics._dists
 from neuralcompression.metrics import DeepImageStructureTextureSimilarity
 
 
 @pytest.mark.parametrize("num_samples", [5])
-def test_dists(num_samples: int, arange_4d_image: Tensor):
+def test_dists(num_samples: int, arange_4d_image: Tensor, monkeypatch, mock_backbone):
     if arange_4d_image.shape[1] != 3:
         return
 
+    monkeypatch.setattr(neuralcompression.metrics._dists, "NoTrainDists", mock_backbone)
     metric = DeepImageStructureTextureSimilarity()
 
     for _ in range(num_samples):

--- a/tests/metrics/test_fid.py
+++ b/tests/metrics/test_fid.py
@@ -8,17 +8,21 @@ import torch
 from torch import Tensor
 
 import neuralcompression.functional as ncF
+import neuralcompression.metrics._fid
 from neuralcompression.metrics import FrechetInceptionDistance
 
 
 @pytest.mark.parametrize("num_samples", [5])
-def test_dists(num_samples: int, arange_4d_image: Tensor):
+def test_fid(num_samples: int, arange_4d_image: Tensor, monkeypatch, mock_backbone):
     if arange_4d_image.shape[1] != 3:
         return
 
     rng = torch.Generator()
     rng.manual_seed(55)
 
+    monkeypatch.setattr(
+        neuralcompression.metrics._fid, "NoTrainInceptionV3", mock_backbone
+    )
     metric = FrechetInceptionDistance()
 
     for _ in range(num_samples):

--- a/tests/metrics/test_fid.py
+++ b/tests/metrics/test_fid.py
@@ -5,6 +5,7 @@
 
 import pytest
 import torch
+from conftest import MockBackbone
 from torch import Tensor
 
 import neuralcompression.functional as ncF
@@ -13,7 +14,7 @@ from neuralcompression.metrics import FrechetInceptionDistance
 
 
 @pytest.mark.parametrize("num_samples", [5])
-def test_fid(num_samples: int, arange_4d_image: Tensor, monkeypatch, mock_backbone):
+def test_fid(num_samples: int, arange_4d_image: Tensor, monkeypatch):
     if arange_4d_image.shape[1] != 3:
         return
 
@@ -21,7 +22,7 @@ def test_fid(num_samples: int, arange_4d_image: Tensor, monkeypatch, mock_backbo
     rng.manual_seed(55)
 
     monkeypatch.setattr(
-        neuralcompression.metrics._fid, "NoTrainInceptionV3", mock_backbone
+        neuralcompression.metrics._fid, "NoTrainInceptionV3", MockBackbone
     )
     metric = FrechetInceptionDistance()
 

--- a/tests/metrics/test_kid.py
+++ b/tests/metrics/test_kid.py
@@ -5,6 +5,7 @@
 
 import pytest
 import torch
+from conftest import MockBackbone
 from torch import Tensor
 
 import neuralcompression.functional as ncF
@@ -13,12 +14,12 @@ from neuralcompression.metrics import KernelInceptionDistance
 
 
 @pytest.mark.parametrize("num_samples", [5])
-def test_kid(num_samples: int, arange_4d_image: Tensor, monkeypatch, mock_backbone):
+def test_kid(num_samples: int, arange_4d_image: Tensor, monkeypatch):
     if arange_4d_image.shape[1] != 3:
         return
 
     monkeypatch.setattr(
-        neuralcompression.metrics._kid, "NoTrainInceptionV3", mock_backbone
+        neuralcompression.metrics._kid, "NoTrainInceptionV3", MockBackbone
     )
     metric = KernelInceptionDistance()
 

--- a/tests/metrics/test_kid.py
+++ b/tests/metrics/test_kid.py
@@ -8,14 +8,18 @@ import torch
 from torch import Tensor
 
 import neuralcompression.functional as ncF
+import neuralcompression.metrics._kid
 from neuralcompression.metrics import KernelInceptionDistance
 
 
 @pytest.mark.parametrize("num_samples", [5])
-def test_dists(num_samples: int, arange_4d_image: Tensor):
+def test_kid(num_samples: int, arange_4d_image: Tensor, monkeypatch, mock_backbone):
     if arange_4d_image.shape[1] != 3:
         return
 
+    monkeypatch.setattr(
+        neuralcompression.metrics._kid, "NoTrainInceptionV3", mock_backbone
+    )
     metric = KernelInceptionDistance()
 
     for _ in range(num_samples):

--- a/tests/metrics/test_pickle_size.py
+++ b/tests/metrics/test_pickle_size.py
@@ -15,13 +15,13 @@ from neuralcompression.metrics import pickle_size_of
 
 @pytest.mark.parametrize("arr_size", [64, 128, 256, (64, 64)])
 def test_pickle_size(arr_size, tmp_path: Path):
-    x = np.reshape(np.arange(np.product(arr_size)), arr_size)
+    x = np.reshape(np.arange(np.prod(arr_size)), arr_size)
 
     obj = {"thearr": x}
 
     mem_size = pickle_size_of(obj)
 
-    tmp_file = f"pickle_size_of_{np.product(arr_size)}.pkl"
+    tmp_file = f"pickle_size_of_{np.prod(arr_size)}.pkl"
     with open(tmp_path / tmp_file, "wb") as f:
         pickle.dump(obj, f)
 

--- a/tests/metrics/test_swav_fid.py
+++ b/tests/metrics/test_swav_fid.py
@@ -8,17 +8,21 @@ import torch
 from torch import Tensor
 
 import neuralcompression.functional as ncF
+import neuralcompression.metrics._fid_swav
 from neuralcompression.metrics import FrechetInceptionDistanceSwAV
 
 
 @pytest.mark.parametrize("num_samples", [5])
-def test_dists(num_samples: int, arange_4d_image: Tensor):
+def test_dists(num_samples: int, arange_4d_image: Tensor, monkeypatch, mock_backbone):
     if arange_4d_image.shape[1] != 3:
         return
 
     rng = torch.Generator()
     rng.manual_seed(60)
 
+    monkeypatch.setattr(
+        neuralcompression.metrics._fid_swav, "NoTrainSwAV", mock_backbone
+    )
     metric = FrechetInceptionDistanceSwAV()
 
     for _ in range(num_samples):

--- a/tests/metrics/test_swav_fid.py
+++ b/tests/metrics/test_swav_fid.py
@@ -5,6 +5,7 @@
 
 import pytest
 import torch
+from conftest import MockBackbone
 from torch import Tensor
 
 import neuralcompression.functional as ncF
@@ -13,7 +14,7 @@ from neuralcompression.metrics import FrechetInceptionDistanceSwAV
 
 
 @pytest.mark.parametrize("num_samples", [5])
-def test_dists(num_samples: int, arange_4d_image: Tensor, monkeypatch, mock_backbone):
+def test_dists(num_samples: int, arange_4d_image: Tensor, monkeypatch):
     if arange_4d_image.shape[1] != 3:
         return
 
@@ -21,7 +22,7 @@ def test_dists(num_samples: int, arange_4d_image: Tensor, monkeypatch, mock_back
     rng.manual_seed(60)
 
     monkeypatch.setattr(
-        neuralcompression.metrics._fid_swav, "NoTrainSwAV", mock_backbone
+        neuralcompression.metrics._fid_swav, "NoTrainSwAV", MockBackbone
     )
     metric = FrechetInceptionDistanceSwAV()
 

--- a/tests/metrics/test_update_patch_fid.py
+++ b/tests/metrics/test_update_patch_fid.py
@@ -5,6 +5,7 @@
 
 import pytest
 import torch
+from conftest import MockBackbone
 from torch import Tensor
 
 import neuralcompression.metrics._fid
@@ -19,18 +20,18 @@ from neuralcompression.metrics import (
 
 
 @pytest.mark.parametrize("num_samples", [5])
-def test_dists(num_samples: int, arange_4d_image: Tensor, monkeypatch, mock_backbone):
+def test_dists(num_samples: int, arange_4d_image: Tensor, monkeypatch):
     if arange_4d_image.shape[1] != 3:
         return
 
     monkeypatch.setattr(
-        neuralcompression.metrics._fid, "NoTrainInceptionV3", mock_backbone
+        neuralcompression.metrics._fid, "NoTrainInceptionV3", MockBackbone
     )
     monkeypatch.setattr(
-        neuralcompression.metrics._fid_swav, "NoTrainSwAV", mock_backbone
+        neuralcompression.metrics._fid_swav, "NoTrainSwAV", MockBackbone
     )
     monkeypatch.setattr(
-        neuralcompression.metrics._kid, "NoTrainInceptionV3", mock_backbone
+        neuralcompression.metrics._kid, "NoTrainInceptionV3", MockBackbone
     )
 
     fid_metric = FrechetInceptionDistance()

--- a/tests/metrics/test_update_patch_fid.py
+++ b/tests/metrics/test_update_patch_fid.py
@@ -7,6 +7,9 @@ import pytest
 import torch
 from torch import Tensor
 
+import neuralcompression.metrics._fid
+import neuralcompression.metrics._fid_swav
+import neuralcompression.metrics._kid
 from neuralcompression.metrics import (
     FrechetInceptionDistance,
     FrechetInceptionDistanceSwAV,
@@ -16,9 +19,19 @@ from neuralcompression.metrics import (
 
 
 @pytest.mark.parametrize("num_samples", [5])
-def test_dists(num_samples: int, arange_4d_image: Tensor):
+def test_dists(num_samples: int, arange_4d_image: Tensor, monkeypatch, mock_backbone):
     if arange_4d_image.shape[1] != 3:
         return
+
+    monkeypatch.setattr(
+        neuralcompression.metrics._fid, "NoTrainInceptionV3", mock_backbone
+    )
+    monkeypatch.setattr(
+        neuralcompression.metrics._fid_swav, "NoTrainSwAV", mock_backbone
+    )
+    monkeypatch.setattr(
+        neuralcompression.metrics._kid, "NoTrainInceptionV3", mock_backbone
+    )
 
     fid_metric = FrechetInceptionDistance()
     fid_swav_metric = FrechetInceptionDistanceSwAV()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,7 +13,7 @@ from PIL import Image
 
 
 def create_input(shape, offset: int = 0):
-    x = np.arange(np.product(shape)).reshape(shape) + offset
+    x = np.arange(np.prod(shape)).reshape(shape) + offset
 
     return torch.from_numpy(x).to(torch.get_default_dtype())
 


### PR DESCRIPTION
This PR should remove model downloads for DISTS, InceptionV3, and ResNet models that are used for the FID, KID, and DISTS metrics tests in our CI testing suite.