### PR TITLE
Add timeout to unit tests to catch flaky test_dense_image_warp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,6 @@ requires = [
 
 [tool.setuptools_scm]
 write_to = "neuralcompression/version.py"
+
+[tool.pytest.ini_options]
+timeout = 300

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,6 +80,7 @@ dev =
     isort>=5.12.0
     mypy>=1.5.1
     pytest>=7.4.0
+    pytest-timeout>=2.3.1
 docs =
     myst-parser>=0.15.2
     sphinx-autodoc-typehints>=1.12.0
@@ -99,6 +100,7 @@ tests =
     opencv-python~=4.8.0.76
     pillow==9.4.0
     pytest==7.4.0
+    pytest-timeout==2.3.1
     pytorchvideo==0.1.5
     scipy==1.11.1
     torch==2.0.1

--- a/tests/functional/test_dense_image_warp.py
+++ b/tests/functional/test_dense_image_warp.py
@@ -5,11 +5,13 @@
 
 import pickle
 
+import pytest
 import torch
 
 from neuralcompression.functional import dense_image_warp
 
 
+@pytest.mark.timeout(method="thread")
 def test_dense_image_warp():
     with open("tests/cached_data/dense_image_warp.pkl", "rb") as f:
         data = pickle.load(f)


### PR DESCRIPTION
The unit test test_dense_image_warp hangs sometimes. I ran it locally 1000 times and I wasn't able to reproduce the error.

This PR adds a timeout to the unit tests, so that we get a stack trace the next time it stalls. Also it doesn't waste 6 hours of compute.

The timeout is set to 5 minutes per test by default.

## Changes

* Adds pytest timeout with the default timeout of 5 minutes.
* Decorate test_dense_image_warp to make sure that a proper stack trace is printed on the next timeout.

## Testing

Tested locally, I saw a stack trace on a timeout:

```
  File "/private/home/marton/miniconda3/envs/waveenv/lib/python3.10/site-packages/pluggy/_manager.py", line 119, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  File "/private/home/marton/miniconda3/envs/waveenv/lib/python3.10/site-packages/pluggy/_callers.py", line 102, in _multicall
    res = hook_impl.function(*args)
  File "/private/home/marton/.local/lib/python3.10/site-packages/_pytest/python.py", line 194, in pytest_pyfunc_call
    result = testfunction(**testargs)
  File "/private/home/marton/NeuralCompressionInternal/tests/functional/test_dense_image_warp.py", line 17, in test_dense_image_warp
    time.sleep(10)
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++ Timeout +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
```
